### PR TITLE
Adding Github Action to publish to Dockerhub

### DIFF
--- a/mirroring/action.yaml
+++ b/mirroring/action.yaml
@@ -1,0 +1,17 @@
+name: Publish Docker Image
+on:
+  release:
+    types:  [published]
+jobs:
+  name: Push Docker image to Docker Hub
+  runs-on: apline-latest
+  steps:
+    - name: Check out the repo
+      uses: actions/checkout@v2
+    - name: Push to Docker Hub
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repostiory: namespace/repository
+        tag_with_ref: true

--- a/mirroring/action.yaml
+++ b/mirroring/action.yaml
@@ -13,5 +13,5 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repostiory: a0su/sigstore_mirroring
+        repository: a0su/sigstore_mirroring
         tag_with_ref: true

--- a/mirroring/action.yaml
+++ b/mirroring/action.yaml
@@ -13,5 +13,5 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        repostiory: namespace/repository
+        repostiory: a0su/sigstore_mirroring
         tag_with_ref: true


### PR DESCRIPTION
We mentioned two standups ago that we would like to create an action for publishing the mirroring agent to dockerhub. To properly integrate this I would need to create a Github Secret to authenticate my push to dockerhub.

I followed along with the documentation here: https://docs.github.com/en/actions/guides/publishing-docker-images