### PR TITLE
Add root hash consistency check

### DIFF
--- a/mirroring/mirroring_test.go
+++ b/mirroring/mirroring_test.go
@@ -31,6 +31,27 @@ func TestVerifySignedTreeHead(t *testing.T) {
 	}
 }
 
+func TestVerifyConsistencyProof(t *testing.T) {
+	viper.Set("rekorServerURL", "https://api.sigstore.dev")
+
+	logInfo, err := GetLogInfo()
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	// Pass in latest tree size witnessed; For now, use current tree size
+	logProof, err := GetLogProof(logInfo.TreeSize)
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	if VerifyConsistencyProof(logInfo.RootHash, logProof) {
+		t.Log("Root Hash Consistency Verified.")
+	} else {
+		t.Log("Root Hash Inconsistency!")
+	}
+}
+
 func TestFetchLeavesByRange(t *testing.T) {
 	viper.Set("rekorServerURL", "https://api.sigstore.dev")
 	viper.Set("tree_file_dir", ".tree")

--- a/mirroring/mirroring_test.go
+++ b/mirroring/mirroring_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sigstore/rekor/pkg/client"
 	"github.com/spf13/viper"
 )
 
@@ -31,24 +32,21 @@ func TestVerifySignedTreeHead(t *testing.T) {
 	}
 }
 
-func TestVerifyConsistencyProof(t *testing.T) {
+func TestVerifyLogConsistency(t *testing.T) {
 	viper.Set("rekorServerURL", "https://api.sigstore.dev")
-
-	logInfo, err := GetLogInfo()
+	rekorClient, err := client.GetRekorClient(viper.GetString("rekorServerURL"))
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
 
-	// Pass in latest tree size witnessed; For now, use current tree size
-	logProof, err := GetLogProof(logInfo.TreeSize)
+	firstEntry, err := GetLogEntryData(0, rekorClient)
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
 
-	if VerifyConsistencyProof(logInfo.RootHash, logProof) {
-		t.Log("Root Hash Consistency Verified.")
-	} else {
-		t.Log("Root Hash Inconsistency!")
+	err = VerifyLogConsistency(1, firstEntry.MerkleTreeHash)
+	if err != nil {
+		t.Errorf("%s\n", err)
 	}
 }
 


### PR DESCRIPTION
I added a very basic root hash consistency check.
1. Grabs the latest log consistency proof from Rekor server
2. Checks if the last seen root hash is part of the latest log consistency proof from step 1

For now, I have simply queried the latest log information to check it against the latest log consistency proof.
Moving forward we can probably temporarily use a text file with latest root hash saved until we actually run the monitor's transparency log that will hold the latest root hash audited.