### PR TITLE
Add inclusion check and fix consistency check

### DIFF
--- a/mirroring/mirroring_test.go
+++ b/mirroring/mirroring_test.go
@@ -39,12 +39,30 @@ func TestVerifyLogConsistency(t *testing.T) {
 		t.Errorf("%s\n", err)
 	}
 
-	firstEntry, err := GetLogEntryData(0, rekorClient)
+	entry, err := GetLogEntryData(0, rekorClient)
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
 
-	err = VerifyLogConsistency(1, firstEntry.MerkleTreeHash)
+	err = VerifyLogConsistency(1, entry.MerkleTreeHash)
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+}
+
+func TestVerifyLogInclusion(t *testing.T) {
+	viper.Set("rekorServerURL", "https://api.sigstore.dev")
+	rekorClient, err := client.GetRekorClient(viper.GetString("rekorServerURL"))
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	entry, err := GetLogEntryData(47906, rekorClient)
+	if err != nil {
+		panic(err)
+	}
+
+	err = VerifyLogInclusion(entry.MerkleTreeHash)
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}


### PR DESCRIPTION
Signed-off-by: Hojoung Jang <jang88@purdue.edu>

#### Summary
- Add a function that performs inclusion check of a given entry
- Fix wrong implementation of root hash computation
  - Previously, the order of concatenating two hashes was not considered 
    ex. `hash(left child hash + right child hash) != hash(right child hash + left child hash)`
  - Used Trillian's implementation which does consider this
