### PR TITLE
Make rekor client instance as an input parameter

### DIFF
--- a/mirroring/mirroring_test.go
+++ b/mirroring/mirroring_test.go
@@ -27,7 +27,22 @@ import (
 
 func TestVerifySignedTreeHead(t *testing.T) {
 	viper.Set("rekorServerURL", "https://api.sigstore.dev")
-	if err := VerifySignedTreeHead(); err != nil {
+	rekorClient, err := client.GetRekorClient(viper.GetString("rekorServerURL"))
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	logInfo, err := GetLogInfo(rekorClient)
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	pubkey, err := GetPublicKey(rekorClient)
+	if err != nil {
+		t.Errorf("%s\n", err)
+	}
+
+	if err := VerifySignedTreeHead(logInfo, pubkey); err != nil {
 		t.Errorf("%s\n", err)
 	}
 }
@@ -44,7 +59,7 @@ func TestVerifyLogConsistency(t *testing.T) {
 		t.Errorf("%s\n", err)
 	}
 
-	err = VerifyLogConsistency(1, entry.MerkleTreeHash)
+	_, _, err = VerifyLogConsistency(rekorClient, 1, entry.MerkleTreeHash)
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}
@@ -62,7 +77,7 @@ func TestVerifyLogInclusion(t *testing.T) {
 		panic(err)
 	}
 
-	err = VerifyLogInclusion(entry.MerkleTreeHash)
+	err = VerifyLogInclusion(rekorClient, entry.MerkleTreeHash)
 	if err != nil {
 		t.Errorf("%s\n", err)
 	}


### PR DESCRIPTION
Signed-off-by: Hojoung Jang <jang88@purdue.edu>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Make necessary refactoring to implement main executable for mirroring job
- Removed rekor client instantiation in all of functions and make it as input parameter
  - This will allow us to resolve any rekor server URL of choice upon rekor client instantiation
- `VerifySignedTreeHead()` -> `VerifySignedTreeHead(logInfo *models.LogInfo, pubkey string)`
  - Takes in `logInfo` containing signed tree head information and corresponding server's public key
  - It made more sense to verify given signed tree head rather than doing querying inside the function and verifying
- `VerifyLogConsistency()` returns the new tree size and root hash upon successful consistency verification
  - Made more sense to return this information so that the old tree data gets updated

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/rekor-monitor/issues/29

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
