### PR TITLE
Run periodically on GitHub Actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ name: Check
 on:
   workflow_dispatch:
   schedule:
-    cron: '0 * * * *' # every hour
+  - cron: '0 * * * *' # every hour
 
 jobs:
   check:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,8 +24,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
+      - uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923 # v2.2.0
         with:
-          go-version: 1.18
+          go-version: 1.16
       - run: go run ./cmd/mirroring --once

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check
+
+on:
+  workflow_dispatch:
+  schedule:
+    cron: '0 * * * *' # every hour
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - run: go run ./cmd/mirroring --once

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ output/*/index.html
 *.metadata
 *.tree
 *.vscode
+
+logInfo.txt


### PR DESCRIPTION
Signed-off-by: Jason Hall <imjasonh@gmail.com>

#### Summary

This adds a GitHub Actions workflow to build and run the monitor code on an hourly schedule. `logInfo.txt` is not persisted between runs, so each run is the "first" run in this case.

This also updates the `--interval` flag to take a duration string (e.g., `--interval=5m`, `--interval=10s`, `--interval=6h`) instead of an integer number of minutes.

It also fixes a few tiny Go nits around error value scoping and usage of `log.Print` and `log.Fatal`.

Run this way, if the periodic scheduled verification fails, an email will be sent to repo owners to alert them. We can also create a badge for this on the repo page.

#### Release Note

Added a `--once` flag to run verification once then exit. `--interval` is updated to take a Go duration string (e.g., `5m`, `10s`, `6h`), and more errors result in failure instead of just logging.

#### Documentation

N/A