### PR TITLE
Refactor main, change order of operations

### DIFF
--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -19,16 +19,15 @@ import (
 	"bufio"
 	"context"
 	"encoding/hex"
-	"errors"
 	"flag"
 	"fmt"
-	"io/fs"
 	"log"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/sigstore/rekor-monitor/pkg/rekor"
+	file "github.com/sigstore/rekor-monitor/pkg/util"
 	"github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/util"
 	"github.com/sigstore/rekor/pkg/verify"
@@ -41,78 +40,7 @@ const (
 	outputIdentitiesFileName = "identities.txt"
 )
 
-// readLatestCheckpoint reads the most recent signed checkpoint
-// from the log file.
-func readLatestCheckpoint(logInfoFile string) (*util.SignedCheckpoint, error) {
-	// Each line in the file is one signed checkpoint
-	file, err := os.Open(logInfoFile)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	// Read line by line and get the last line
-	scanner := bufio.NewScanner(file)
-	line := ""
-	for scanner.Scan() {
-		line = scanner.Text()
-	}
-
-	sth := util.SignedCheckpoint{}
-	if err := sth.UnmarshalText([]byte(strings.ReplaceAll(line, "\\n", "\n"))); err != nil {
-		return nil, err
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-
-	return &sth, nil
-}
-
-// deleteOldCheckpoints persists the latest 100 checkpoints. This expects that the log file
-// is not being concurrently written to.
-func deleteOldCheckpoints(logInfoFile string) error {
-	// read all lines from file
-	file, err := os.Open(logInfoFile)
-	if err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(file)
-	var lines []string
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	if err := file.Close(); err != nil {
-		return err
-	}
-
-	// exit early if there aren't checkpoints to truncate
-	if len(lines) <= 100 {
-		return nil
-	}
-
-	// open file again to overwrite
-	file, err = os.OpenFile(logInfoFile, os.O_RDWR|os.O_TRUNC, 0666)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	for i := len(lines) - 100; i < len(lines); i++ {
-		if _, err := file.WriteString(fmt.Sprintf("%s\n", lines[i])); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func ParseIdentities(identitiesInput string) (rekor.Identities, error) {
+func parseIdentities(identitiesInput string) (rekor.Identities, error) {
 	ids := rekor.Identities{}
 	scanner := bufio.NewScanner(strings.NewReader(identitiesInput))
 	for scanner.Scan() {
@@ -147,7 +75,7 @@ func main() {
 		"Name of the file containing indices and identities found in the log. Format is \"subject issuer index uuid\"")
 	flag.Parse()
 
-	ids, err := ParseIdentities(*identitiesInput)
+	ids, err := parseIdentities(*identitiesInput)
 	if err != nil {
 		log.Fatalf("error parsing identities: %v", err)
 	}
@@ -164,146 +92,92 @@ func main() {
 		log.Fatalf("getting Rekor client: %v", err)
 	}
 
-	// Fetch log info to get total log size and initial STH if needed
-	logInfo, err := rekor.GetLogInfo(context.Background(), rekorClient)
-	if err != nil {
-		log.Fatalf("Getting log info: %v", err)
-	}
-
-	var sth *util.SignedCheckpoint
-	var first bool
-
-	// TODO: Change order of operations:
-	// * Fetch latest STH and verify
-	// * If old STH is present, very consistency proof
-	// * Write new STH to log
-
-	_, err = os.Stat(*logInfoFile)
-	switch {
-	case err == nil:
-		// File containing previous checkpoints exists
-		sth, err = readLatestCheckpoint(*logInfoFile)
-		if err != nil {
-			log.Fatalf("reading checkpoint log: %v", err)
-		}
-	case errors.Is(err, fs.ErrNotExist):
-		// No old snapshot data available, read latest checkpoint
-		sth = &util.SignedCheckpoint{}
-		if err := sth.UnmarshalText([]byte(*logInfo.SignedTreeHead)); err != nil {
-			log.Fatalf("unmarshalling logInfo.SignedTreeHead to Checkpoint: %v", err)
-		}
-		first = true
-	default:
-		// Any other errors reading the file
-		log.Fatalf("reading %q: %v", *logInfoFile, err)
-	}
-
 	verifier, err := rekor.GetLogVerifier(context.Background(), rekorClient)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Verify the checkpoint with the server's public key
-	if !sth.Verify(verifier) {
-		log.Fatalf("verifying checkpoint (size %d, hash %s) failed", sth.Size, hex.EncodeToString(sth.Hash))
-	}
-	fmt.Fprintf(os.Stderr, "Current checkpoint verified - Tree Size: %d Root Hash: %s\n", sth.Size, hex.EncodeToString(sth.Hash))
-
-	// If this is the very first snapshot within the monitor, save the snapshot
-	if first {
-		s, err := sth.SignedNote.MarshalText()
-		if err != nil {
-			log.Fatalf("failed to marshal checkpoint: %v", err)
-		}
-
-		// Open file to create new snapshot
-		file, err := os.OpenFile(*logInfoFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			file.Close()
-			log.Fatalf("failed to open log file: %v", err)
-		}
-
-		// Replace newlines to flatten checkpoint to single line
-		if _, err := file.WriteString(fmt.Sprintf("%s\n", strings.ReplaceAll(string(s), "\n", "\\n"))); err != nil {
-			file.Close()
-			log.Fatalf("failed to write to file: %v", err)
-		}
-		file.Close()
-	}
-
+	// Loop will:
+	// 1. Fetch latest checkpoint and verify
+	// 2. If old checkpoint is present, verify consistency proof
+	// 3. Write latest checkpoint to file
 	for {
-		// Check for root hash consistency
-		newSTH, err := verify.VerifyCurrentCheckpoint(context.Background(), rekorClient, verifier, sth)
+		logInfo, err := rekor.GetLogInfo(context.Background(), rekorClient)
 		if err != nil {
-			log.Fatalf("failed to verify log consistency: %v", err)
+			log.Fatalf("Getting log info: %v", err)
 		}
-		fmt.Fprintf(os.Stderr, "Root hash consistency verified - Tree Size: %d Root Hash: %s\n", newSTH.Size, hex.EncodeToString(newSTH.Hash))
-
-		// Get log size of inactive shards
-		totalSize := 0
-		for _, s := range logInfo.InactiveShards {
-			totalSize += int(*s.TreeSize)
+		checkpoint := &util.SignedCheckpoint{}
+		if err := checkpoint.UnmarshalText([]byte(*logInfo.SignedTreeHead)); err != nil {
+			log.Fatalf("unmarshalling logInfo.SignedTreeHead to Checkpoint: %v", err)
 		}
-		startIndex := int(sth.Size) + totalSize - 1
-		endIndex := int(newSTH.Size) + totalSize - 1
+		if !checkpoint.Verify(verifier) {
+			log.Fatalf("verifying checkpoint (size %d, hash %s) failed", checkpoint.Size, hex.EncodeToString(checkpoint.Hash))
+		}
 
-		// Append new, consistency-checked snapshot
-		if newSTH.Size != sth.Size {
-			s, err := newSTH.SignedNote.MarshalText()
+		fi, err := os.Stat(*logInfoFile)
+		var prevCheckpoint *util.SignedCheckpoint
+		if err == nil && fi.Size() != 0 {
+			// File containing previous checkpoints exists
+			prevCheckpoint, err = file.ReadLatestCheckpoint(*logInfoFile)
 			if err != nil {
-				log.Fatalf("failed to marshal STH: %v", err)
+				log.Fatalf("reading checkpoint log: %v", err)
 			}
-
-			// Open file to append new snapshot
-			file, err := os.OpenFile(*logInfoFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			if err != nil {
-				file.Close()
-				log.Fatalf("failed to open log file: %v", err)
+			if !prevCheckpoint.Verify(verifier) {
+				log.Fatalf("verifying checkpoint (size %d, hash %s) failed", checkpoint.Size, hex.EncodeToString(checkpoint.Hash))
 			}
-
-			// Replace newlines to flatten checkpoint to single line
-			if _, err := file.WriteString(fmt.Sprintf("%s\n", strings.ReplaceAll(string(s), "\n", "\\n"))); err != nil {
-				file.Close()
-				log.Fatalf("failed to write to file: %v", err)
+		}
+		if prevCheckpoint != nil {
+			if err := verify.ProveConsistency(context.Background(), rekorClient, prevCheckpoint, checkpoint, *logInfo.TreeID); err != nil {
+				log.Fatalf("failed to verify log consistency: %v", err)
 			}
-			file.Close()
+			fmt.Fprintf(os.Stderr, "Root hash consistency verified - Current Size: %d Root Hash: %s - Previous Size: %d Root Hash %s\n",
+				checkpoint.Size, hex.EncodeToString(checkpoint.Hash), prevCheckpoint.Size, hex.EncodeToString(prevCheckpoint.Hash))
+		}
 
-			sth = newSTH
+		// Write if there was no stored checkpoint or the sizes differ
+		if prevCheckpoint == nil || prevCheckpoint.Size != checkpoint.Size {
+			if err := file.WriteCheckpoint(checkpoint, *logInfoFile); err != nil {
+				log.Fatalf("failed to write checkpoint: %v", err)
+			}
 		}
 
 		// TODO: Switch to writing checkpoints to GitHub so that the history is preserved. Then we only need
 		// to persist the last checkpoint.
 		// Delete old checkpoints to avoid the log growing indefinitely
-		if err := deleteOldCheckpoints(*logInfoFile); err != nil {
+		if err := file.DeleteOldCheckpoints(*logInfoFile); err != nil {
 			log.Fatalf("failed to delete old checkpoints: %v", err)
 		}
 
-		// Search for identities in the log range
-		if len(ids.Identities) > 0 {
-			entries, err := rekor.GetEntriesByIndexRange(context.Background(), rekorClient, startIndex, endIndex)
-			if err != nil {
-				log.Fatalf("error getting entries by index range: %v", err)
+		// Look for identities if there was a previous, different checkpoint
+		if prevCheckpoint != nil && prevCheckpoint.Size != checkpoint.Size {
+			// Get log size of inactive shards
+			totalSize := 0
+			for _, s := range logInfo.InactiveShards {
+				totalSize += int(*s.TreeSize)
 			}
-			idEntries, err := rekor.MatchedIndices(entries, ids)
-			if err != nil {
-				log.Fatalf("error finding log indices: %v", err)
-			}
+			startIndex := int(prevCheckpoint.Size) + totalSize - 1
+			endIndex := int(checkpoint.Size) + totalSize - 1
 
-			if len(idEntries) > 0 {
-				for _, idEntry := range idEntries {
-					fmt.Fprintf(os.Stderr, "Found subject %s, issuer %s at log index %d, uuid %s\n",
-						idEntry.Subject, idEntry.Issuer, idEntry.Index, idEntry.UUID)
+			// Search for identities in the log range
+			if len(ids.Identities) > 0 {
+				entries, err := rekor.GetEntriesByIndexRange(context.Background(), rekorClient, startIndex, endIndex)
+				if err != nil {
+					log.Fatalf("error getting entries by index range: %v", err)
+				}
+				idEntries, err := rekor.MatchedIndices(entries, ids)
+				if err != nil {
+					log.Fatalf("error finding log indices: %v", err)
+				}
 
-					idFile, err := os.OpenFile(*outputIdentitiesFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-					if err != nil {
-						idFile.Close()
-						log.Fatalf("failed to open identities file: %v", err)
+				if len(idEntries) > 0 {
+					for _, idEntry := range idEntries {
+						fmt.Fprintf(os.Stderr, "Found subject %s, issuer %s at log index %d, uuid %s\n",
+							idEntry.Subject, idEntry.Issuer, idEntry.Index, idEntry.UUID)
+
+						if err := file.WriteIdentity(*outputIdentitiesFile, idEntry); err != nil {
+							log.Fatalf("failed to write identity: %v", err)
+						}
 					}
-					if _, err := idFile.WriteString(fmt.Sprintf("%s %s %d %s\n", idEntry.Subject, idEntry.Issuer, idEntry.Index, idEntry.UUID)); err != nil {
-						idFile.Close()
-						log.Fatalf("failed to write to file: %v", err)
-					}
-					idFile.Close()
 				}
 			}
 		}

--- a/pkg/rekor/client.go
+++ b/pkg/rekor/client.go
@@ -35,9 +35,12 @@ func GetPublicKey(ctx context.Context, rekorClient *client.Rekor) ([]byte, error
 	return []byte(pubkeyResp.Payload), nil
 }
 
-// GetLogInfo fetches checkpoints and log information for each log shard
+// GetLogInfo fetches a stable checkpoint for each log shard
 func GetLogInfo(ctx context.Context, rekorClient *client.Rekor) (*models.LogInfo, error) {
 	p := tlog.NewGetLogInfoParamsWithContext(ctx)
+	stable := true
+	p.Stable = &stable
+
 	logInfoResp, err := rekorClient.Tlog.GetLogInfo(p)
 	if err != nil {
 		return nil, err

--- a/pkg/util/file.go
+++ b/pkg/util/file.go
@@ -1,0 +1,133 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sigstore/rekor-monitor/pkg/rekor"
+	"github.com/sigstore/rekor/pkg/util"
+)
+
+// ReadLatestCheckpoint reads the most recent signed checkpoint from the log file
+func ReadLatestCheckpoint(logInfoFile string) (*util.SignedCheckpoint, error) {
+	// Each line in the file is one signed checkpoint
+	file, err := os.Open(logInfoFile)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	// Read line by line and get the last line
+	scanner := bufio.NewScanner(file)
+	line := ""
+	for scanner.Scan() {
+		line = scanner.Text()
+	}
+
+	checkpoint := util.SignedCheckpoint{}
+	if err := checkpoint.UnmarshalText([]byte(strings.ReplaceAll(line, "\\n", "\n"))); err != nil {
+		return nil, err
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &checkpoint, nil
+}
+
+// WriteCheckpoint writes a signed checkpoint to the log file
+func WriteCheckpoint(checkpoint *util.SignedCheckpoint, logInfoFile string) error {
+	// Write latest checkpoint to file
+	s, err := checkpoint.SignedNote.MarshalText()
+	if err != nil {
+		return fmt.Errorf("failed to marshal checkpoint: %w", err)
+	}
+	// Open file to append new snapshot
+	file, err := os.OpenFile(logInfoFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening file: %w", err)
+	}
+	defer file.Close()
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	// Replace newlines to flatten checkpoint to single line
+	if _, err := file.WriteString(fmt.Sprintf("%s\n", strings.ReplaceAll(string(s), "\n", "\\n"))); err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+	return nil
+}
+
+// DeleteOldCheckpoints persists the latest 100 checkpoints. This expects that the log file
+// is not being concurrently written to
+func DeleteOldCheckpoints(logInfoFile string) error {
+	// read all lines from file
+	file, err := os.Open(logInfoFile)
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(file)
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	// exit early if there aren't checkpoints to truncate
+	if len(lines) <= 100 {
+		return nil
+	}
+
+	// open file again to overwrite
+	file, err = os.OpenFile(logInfoFile, os.O_RDWR|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for i := len(lines) - 100; i < len(lines); i++ {
+		if _, err := file.WriteString(fmt.Sprintf("%s\n", lines[i])); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WriteIdentity writes an identity found in the log to a file
+func WriteIdentity(idFile string, idEntry rekor.IdentityEntry) error {
+	file, err := os.OpenFile(idFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open identities file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(fmt.Sprintf("%s %s %d %s\n", idEntry.Subject, idEntry.Issuer, idEntry.Index, idEntry.UUID)); err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/util/file_test.go
+++ b/pkg/util/file_test.go
@@ -1,0 +1,127 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/rekor/pkg/util"
+	"golang.org/x/mod/sumdb/note"
+)
+
+func TestReadLatestCheckpoint(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "logfile")
+	root, _ := hex.DecodeString("1a341bc342ff4e567387de9789ab14000b147124317841489172419874198147")
+
+	// success: read checkpoint
+	// generate fake checkpoint
+	sc, err := util.CreateSignedCheckpoint(util.Checkpoint{
+		Origin: "origin",
+		Size:   uint64(123),
+		Hash:   root,
+	})
+	sc.Signatures = []note.Signature{{Name: "name", Hash: 1, Base64: "adbadbadb"}}
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, err := sc.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := fmt.Sprintf("%s\n", strings.ReplaceAll(string(text), "\n", "\\n"))
+	err = os.WriteFile(f, []byte(data), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := ReadLatestCheckpoint(f)
+	if err != nil {
+		t.Fatalf("error reading checkpoint: %v", err)
+	}
+	result, _ := c.MarshalText()
+	if !bytes.Equal(text, result) {
+		log.Fatalf("checkpoints are not equal")
+	}
+
+	// failure: no log file
+	_, err = ReadLatestCheckpoint("empty")
+	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// failure: malformed note
+	os.WriteFile(f, []byte{1}, 0644)
+	_, err = ReadLatestCheckpoint(f)
+	if err == nil || !strings.Contains(err.Error(), "malformed note") {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestWriteAndRead(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "logfile")
+	root, _ := hex.DecodeString("1a341bc342ff4e567387de9789ab14000b147124317841489172419874198147")
+
+	// success: read and write checkpoint
+	// generate fake checkpoint
+	sc, err := util.CreateSignedCheckpoint(util.Checkpoint{
+		Origin: "origin",
+		Size:   uint64(123),
+		Hash:   root,
+	})
+	sc.Signatures = []note.Signature{{Name: "name", Hash: 1, Base64: "adbadbadb"}}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCheckpoint(sc, f); err != nil {
+		t.Fatalf("error writing checkpoint: %v", err)
+	}
+	c, err := ReadLatestCheckpoint(f)
+	if err != nil {
+		t.Fatalf("error reading checkpoint: %v", err)
+	}
+	input, _ := sc.MarshalText()
+	result, _ := c.MarshalText()
+	if !bytes.Equal(input, result) {
+		log.Fatalf("checkpoints are not equal")
+	}
+}
+
+func TestDeleteOldCheckpoints(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "logfile")
+	file, _ := os.OpenFile(f, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	// log size will be 200 by end of loop
+	for i := 0; i < 200; i++ {
+		file.WriteString("\n")
+	}
+	fi, _ := os.Stat(f)
+	if fi.Size() != 200 {
+		t.Fatalf("log size should be 200, got %d", fi.Size())
+	}
+
+	if err := DeleteOldCheckpoints(f); err != nil {
+		t.Fatalf("error deleting: %v", err)
+	}
+
+	fi, _ = os.Stat(f)
+	if fi.Size() != 100 {
+		t.Fatalf("log size should be 100, got %d", fi.Size())
+	}
+}


### PR DESCRIPTION
No change in functionality, just cleaning up the main function, getting rid of the hard-to-understand handling of a first checkpoint.

Changes:
* Fetch stable checkpoint rather than latest checkpoint
* Change loop to fetch checkpoint, verify a consistency proof only if no previous checkpoint exists, and always write. This improves readability.
* Move file functions to util folder
* Handle empty log file

Fixes #52
Fixes #226
Fixes #103

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
