### PR TITLE
implement support for OID monitoring

### DIFF
--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -61,9 +61,9 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	hashedrekord := &hashedrekord_v001.V001Entry{}
-	h := sha256.Sum256(payload)
+	hash := sha256.Sum256(payload)
 	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
-		ArtifactHash:   hex.EncodeToString(h[:]),
+		ArtifactHash:   hex.EncodeToString(hash[:]),
 		SignatureBytes: sig,
 		PublicKeyBytes: [][]byte{pemCert},
 		PKIFormat:      "x509",
@@ -82,12 +82,12 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	integratedTime := time.Now()
 	logIndex := 1234
 	uuid := "123-456-123"
-	e := models.LogEntryAnon{
+	logEntryAnon := models.LogEntryAnon{
 		Body:           base64.StdEncoding.EncodeToString(leaf),
 		IntegratedTime: swag.Int64(integratedTime.Unix()),
 		LogIndex:       swag.Int64(int64(logIndex)),
 	}
-	logEntry := models.LogEntry{uuid: e}
+	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
 	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
@@ -168,12 +168,12 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		integratedTime := time.Now()
 		logIndex := 1234
 		uuid := "123-456-123"
-		e := models.LogEntryAnon{
+		logEntryAnon := models.LogEntryAnon{
 			Body:           base64.StdEncoding.EncodeToString(leaf),
 			IntegratedTime: swag.Int64(integratedTime.Unix()),
 			LogIndex:       swag.Int64(int64(logIndex)),
 		}
-		logEntry := models.LogEntry{uuid: e}
+		logEntry := models.LogEntry{uuid: logEntryAnon}
 
 		matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
 			CertificateIdentities: []CertificateIdentity{
@@ -242,9 +242,9 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	}
 
 	hashedrekord := &hashedrekord_v001.V001Entry{}
-	h := sha256.Sum256(payload)
+	hash := sha256.Sum256(payload)
 	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
-		ArtifactHash:   hex.EncodeToString(h[:]),
+		ArtifactHash:   hex.EncodeToString(hash[:]),
 		SignatureBytes: sig,
 		PublicKeyBytes: [][]byte{pemCert},
 		PKIFormat:      "x509",
@@ -263,12 +263,12 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	integratedTime := time.Now()
 	logIndex := 1234
 	uuid := "123-456-123"
-	e := models.LogEntryAnon{
+	logEntryAnon := models.LogEntryAnon{
 		Body:           base64.StdEncoding.EncodeToString(leaf),
 		IntegratedTime: swag.Int64(integratedTime.Unix()),
 		LogIndex:       swag.Int64(int64(logIndex)),
 	}
-	logEntry := models.LogEntry{uuid: e}
+	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
 	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
@@ -313,9 +313,9 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 
 	hashedrekord := &hashedrekord_v001.V001Entry{}
-	h := sha256.Sum256(payload)
+	hash := sha256.Sum256(payload)
 	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
-		ArtifactHash:   hex.EncodeToString(h[:]),
+		ArtifactHash:   hex.EncodeToString(hash[:]),
 		SignatureBytes: sig,
 		PublicKeyBytes: [][]byte{pemKey},
 		PKIFormat:      "x509",
@@ -334,12 +334,12 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	integratedTime := time.Now()
 	logIndex := 1234
 	uuid := "123-456-123"
-	e := models.LogEntryAnon{
+	logEntryAnon := models.LogEntryAnon{
 		Body:           base64.StdEncoding.EncodeToString(leaf),
 		IntegratedTime: swag.Int64(integratedTime.Unix()),
 		LogIndex:       swag.Int64(int64(logIndex)),
 	}
-	logEntry := models.LogEntry{uuid: e}
+	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	derKey, err := cryptoutils.MarshalPublicKeyToDER(key.Public())
 	if err != nil {
@@ -402,9 +402,9 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 
 	hashedrekord := &hashedrekord_v001.V001Entry{}
-	h := sha256.Sum256(payload)
+	hash := sha256.Sum256(payload)
 	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
-		ArtifactHash:   hex.EncodeToString(h[:]),
+		ArtifactHash:   hex.EncodeToString(hash[:]),
 		SignatureBytes: sig,
 		PublicKeyBytes: [][]byte{pemCert},
 		PKIFormat:      "x509",
@@ -423,12 +423,12 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	integratedTime := time.Now()
 	logIndex := 1234
 	uuid := "123-456-123"
-	e := models.LogEntryAnon{
+	logEntryAnon := models.LogEntryAnon{
 		Body:           base64.StdEncoding.EncodeToString(leaf),
 		IntegratedTime: swag.Int64(integratedTime.Unix()),
 		LogIndex:       swag.Int64(int64(logIndex)),
 	}
-	logEntry := models.LogEntry{uuid: e}
+	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
 	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
@@ -496,9 +496,9 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	}
 
 	hashedrekord := &hashedrekord_v001.V001Entry{}
-	h := sha256.Sum256(payload)
+	hash := sha256.Sum256(payload)
 	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
-		ArtifactHash:   hex.EncodeToString(h[:]),
+		ArtifactHash:   hex.EncodeToString(hash[:]),
 		SignatureBytes: sig,
 		PublicKeyBytes: [][]byte{pemCert},
 		PKIFormat:      "x509",
@@ -517,19 +517,19 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	integratedTime := time.Now()
 	logIndex := 1234
 	uuid := "123-456-123"
-	e := models.LogEntryAnon{
+	logEntryAnon := models.LogEntryAnon{
 		Body:           base64.StdEncoding.EncodeToString(leaf),
 		IntegratedTime: swag.Int64(integratedTime.Unix()),
 		LogIndex:       swag.Int64(int64(logIndex)),
 	}
-	logEntry := models.LogEntry{uuid: e}
+	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
 	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
 		OIDMatchers: []OIDMatcher{
 			{
-				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
-				ExtensionValues:  []string{"test cert value"},
+				ObjectIdentifier: oid,
+				ExtensionValues:  []string{extValueString},
 			},
 		}})
 	if err != nil {
@@ -577,15 +577,17 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 
 }
 
-func TestMatchedIndicesFailures(t *testing.T) {
+func TestMatchedIndicesFailuresNoMonitoredValues(t *testing.T) {
 	// failure: no monitored values
 	_, err := MatchedIndices(nil, MonitoredValues{})
 	if err == nil || !strings.Contains(err.Error(), "no identities provided to monitor") {
 		t.Fatalf("expected error with no identities, got %v", err)
 	}
+}
 
+func TestMatchedIndicesFailuresCertSubjectEmpty(t *testing.T) {
 	// failure: certificate subject empty
-	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err := MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
 		{
 			CertSubject: "",
 		},
@@ -593,9 +595,11 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "certificate subject empty") {
 		t.Fatalf("expected error with empty cert subject, got %v", err)
 	}
+}
 
+func TestMatchedIndicesFailuresIssueEmpty(t *testing.T) {
 	// failure: issuer empty
-	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err := MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
 		{
 			CertSubject: "s",
 			Issuers:     []string{""},
@@ -604,39 +608,49 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "issuer empty") {
 		t.Fatalf("expected error with empty issuer, got %v", err)
 	}
+}
 
+func TestMatchedIndicesFailuresSubjectEmpty(t *testing.T) {
 	// failure: subject empty
-	_, err = MatchedIndices(nil, MonitoredValues{Subjects: []string{""}})
+	_, err := MatchedIndices(nil, MonitoredValues{Subjects: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "subject empty") {
 		t.Fatalf("expected error with empty subject, got %v", err)
 	}
+}
 
+func TestMatchedIndicesFailuresFingerprintsEmpty(t *testing.T) {
 	// failure: fingerprint empty
-	_, err = MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
+	_, err := MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "fingerprint empty") {
 		t.Fatalf("expected error with empty fingerprint, got %v", err)
 	}
+}
 
+func TestMatchedIndicesFailuresOIDExtensionEmpty(t *testing.T) {
 	// failure: oid extension empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{},
 		ExtensionValues:  []string{""},
 	}}})
 	if err == nil || !strings.Contains(err.Error(), "oid extension empty") {
 		t.Fatalf("expected error with empty oid extension, got %v", err)
 	}
+}
 
-	// failure: oid matched values list empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+func TestMatchedIndicesFailuresOIDExtensionValuesEmpty(t *testing.T) {
+	// failure: oid extension values list empty
+	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{},
 	}}})
 	if err == nil || !strings.Contains(err.Error(), "oid matched values empty") {
 		t.Fatalf("expected error with empty oid matched values list, got %v", err)
 	}
+}
 
-	// failure: oid matched value string empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+func TestMatchedIndicesFailuresOIDExtensionValueEmpty(t *testing.T) {
+	// failure: oid extension value string empty
+	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{""},
 	}}})
@@ -684,8 +698,8 @@ func TestOIDNotPresent(t *testing.T) {
 	extensionValues := []string{"wrong value"}
 
 	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
-	if matches || err == nil {
-		t.Errorf("Expected false with error, got %v, error %v", matches, err)
+	if matches || err != nil {
+		t.Errorf("Expected false with nil, got %v, error %v", matches, err)
 	}
 }
 

--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -577,17 +577,15 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 
 }
 
-func TestMatchedIndicesFailuresNoMonitoredValues(t *testing.T) {
+func TestMatchedIndicesFailures(t *testing.T) {
 	// failure: no monitored values
 	_, err := MatchedIndices(nil, MonitoredValues{})
 	if err == nil || !strings.Contains(err.Error(), "no identities provided to monitor") {
 		t.Fatalf("expected error with no identities, got %v", err)
 	}
-}
 
-func TestMatchedIndicesFailuresCertSubjectEmpty(t *testing.T) {
 	// failure: certificate subject empty
-	_, err := MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
 		{
 			CertSubject: "",
 		},
@@ -595,11 +593,9 @@ func TestMatchedIndicesFailuresCertSubjectEmpty(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "certificate subject empty") {
 		t.Fatalf("expected error with empty cert subject, got %v", err)
 	}
-}
 
-func TestMatchedIndicesFailuresIssueEmpty(t *testing.T) {
 	// failure: issuer empty
-	_, err := MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
 		{
 			CertSubject: "s",
 			Issuers:     []string{""},
@@ -608,19 +604,15 @@ func TestMatchedIndicesFailuresIssueEmpty(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "issuer empty") {
 		t.Fatalf("expected error with empty issuer, got %v", err)
 	}
-}
 
-func TestMatchedIndicesFailuresSubjectEmpty(t *testing.T) {
 	// failure: subject empty
-	_, err := MatchedIndices(nil, MonitoredValues{Subjects: []string{""}})
+	_, err = MatchedIndices(nil, MonitoredValues{Subjects: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "subject empty") {
 		t.Fatalf("expected error with empty subject, got %v", err)
 	}
-}
 
-func TestMatchedIndicesFailuresFingerprintsEmpty(t *testing.T) {
 	// failure: fingerprint empty
-	_, err := MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
+	_, err = MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "fingerprint empty") {
 		t.Fatalf("expected error with empty fingerprint, got %v", err)
 	}
@@ -685,7 +677,7 @@ func TestOIDDoesNotMatch(t *testing.T) {
 	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
 	extensionValues := []string{"wrong value"}
 
-	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	matches, _, _, err := oidMatchesPolicy(cert, oid, extensionValues)
 	if matches || err != nil {
 		t.Errorf("Expected false without error, got %v, error %v", matches, err)
 	}
@@ -697,7 +689,7 @@ func TestOIDNotPresent(t *testing.T) {
 	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
 	extensionValues := []string{"wrong value"}
 
-	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	matches, _, _, err := oidMatchesPolicy(cert, oid, extensionValues)
 	if matches || err != nil {
 		t.Errorf("Expected false with nil, got %v, error %v", matches, err)
 	}
@@ -710,10 +702,17 @@ func TestOIDMatchesValue(t *testing.T) {
 		t.Errorf("Expected nil got %v", err)
 	}
 	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
-	extensionValues := []string{"test cert value"}
+	extValueString := "test cert value"
+	extensionValues := []string{extValueString}
 
-	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	matches, matchedOID, extValue, err := oidMatchesPolicy(cert, oid, extensionValues)
 	if !matches || err != nil {
 		t.Errorf("Expected true, got %v, error %v", matches, err)
+	}
+	if matchedOID.String() != oid.String() {
+		t.Errorf("Expected oid to equal 2.5.29.17, got %s", matchedOID.String())
+	}
+	if extValue != extValueString {
+		t.Errorf("Expected string to equal 'test cert value', got %s", extValue)
 	}
 }

--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -22,6 +22,9 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
 	"strings"
@@ -461,6 +464,119 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 }
 
+func TestMatchedIndicesForOIDMatchers(t *testing.T) {
+	subject := "subject"
+	issuer := "oidc-issuer@domain.com"
+
+	oid := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9}
+	extValueString := "test cert value"
+	extValue, err := asn1.Marshal(extValueString)
+	if err != nil {
+		t.Fatal(err)
+	}
+	extension := pkix.Extension{
+		Id:       oid,
+		Critical: false,
+		Value:    extValue,
+	}
+
+	rootCert, rootKey, _ := test.GenerateRootCA()
+	leafCert, leafKey, _ := test.GenerateLeafCert(subject, issuer, rootCert, rootKey, extension)
+
+	signer, err := signature.LoadECDSASignerVerifier(leafKey, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemCert, _ := cryptoutils.MarshalCertificateToPEM(leafCert)
+
+	payload := []byte{1, 2, 3, 4}
+	sig, err := signer.SignMessage(bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hashedrekord := &hashedrekord_v001.V001Entry{}
+	h := sha256.Sum256(payload)
+	pe, err := hashedrekord.CreateFromArtifactProperties(context.Background(), types.ArtifactProperties{
+		ArtifactHash:   hex.EncodeToString(h[:]),
+		SignatureBytes: sig,
+		PublicKeyBytes: [][]byte{pemCert},
+		PKIFormat:      "x509",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := types.UnmarshalEntry(pe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := entry.Canonicalize(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	integratedTime := time.Now()
+	logIndex := 1234
+	uuid := "123-456-123"
+	e := models.LogEntryAnon{
+		Body:           base64.StdEncoding.EncodeToString(leaf),
+		IntegratedTime: swag.Int64(integratedTime.Unix()),
+		LogIndex:       swag.Int64(int64(logIndex)),
+	}
+	logEntry := models.LogEntry{uuid: e}
+
+	// match to oid with matching extension value
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+		OIDMatchers: []OIDMatcher{
+			{
+				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
+				ExtensionValues:  []string{"test cert value"},
+			},
+		}})
+	if err != nil {
+		t.Fatalf("expected error matching IDs, got %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	}
+	if matches[0].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	}
+
+	// no match to oid with different extension value
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+		OIDMatchers: []OIDMatcher{
+			{
+				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
+				ExtensionValues:  []string{"wrong"},
+			},
+		}})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(matches))
+	}
+
+	// no match to oid with different oid extension field
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+		OIDMatchers: []OIDMatcher{
+			{
+				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 14},
+				ExtensionValues:  []string{"test cert value"},
+			},
+		}})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no matches, got %d", len(matches))
+	}
+
+}
+
 func TestMatchedIndicesFailures(t *testing.T) {
 	// failure: no monitored values
 	_, err := MatchedIndices(nil, MonitoredValues{})
@@ -499,5 +615,91 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	_, err = MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "fingerprint empty") {
 		t.Fatalf("expected error with empty fingerprint, got %v", err)
+	}
+
+	// failure: oid extension empty
+	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{},
+		ExtensionValues:  []string{""},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "oid extension empty") {
+		t.Fatalf("expected error with empty oid extension, got %v", err)
+	}
+
+	// failure: oid matched values list empty
+	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "oid matched values empty") {
+		t.Fatalf("expected error with empty oid matched values list, got %v", err)
+	}
+
+	// failure: oid matched value string empty
+	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{""},
+	}}})
+	if err == nil || !strings.Contains(err.Error(), "oid matched value empty") {
+		t.Fatalf("expected error with empty oid matched value string, got %v", err)
+	}
+}
+
+func mockCertificateWithExtension(oid asn1.ObjectIdentifier, value string) (*x509.Certificate, error) {
+	extValue, err := asn1.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	cert := &x509.Certificate{
+		Extensions: []pkix.Extension{
+			{
+				Id:       oid,
+				Critical: false,
+				Value:    extValue,
+			},
+		},
+	}
+	return cert, nil
+}
+
+// Test when OID is present but the value does not match
+func TestOIDDoesNotMatch(t *testing.T) {
+	cert, err := mockCertificateWithExtension(asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"wrong value"}
+
+	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	if matches || err != nil {
+		t.Errorf("Expected false without error, got %v, error %v", matches, err)
+	}
+}
+
+// Test when OID is not present in the certificate
+func TestOIDNotPresent(t *testing.T) {
+	cert := &x509.Certificate{} // No extensions
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"wrong value"}
+
+	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	if matches || err == nil {
+		t.Errorf("Expected false with error, got %v, error %v", matches, err)
+	}
+}
+
+// Test when OID is present and matches value
+func TestOIDMatchesValue(t *testing.T) {
+	cert, err := mockCertificateWithExtension(asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"test cert value"}
+
+	matches, err := oidMatchesPolicy(cert, oid, extensionValues)
+	if !matches || err != nil {
+		t.Errorf("Expected true, got %v, error %v", matches, err)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As documented [here](https://docs.google.com/document/d/1YcC31YmnCSwL1GRbC7LSor-YY6qhk3ynMhN1UNT-Wyw/edit?pli=1&resourcekey=0-OoutF_Qh1Q5q0p4ZPYXncA&tab=t.0#heading=h.xgjl2srtytjt), this PR aims to implement support for monitoring OID extension values in rekor-monitor. Users can input OID extension fields and associated values as parameters in their monitor workflow action, allowing the monitor to filter log entries based on matching OID values.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

OID extensions and associated values are now supported as parameters in the rekor-monitor workflow task.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

New OID arguments will be reflected in the rekor-monitor README in additional PRs, which will add support for OIDMatchers as CLI and GitHub Actions arguments in both named fields and in dot notation.
