### PR TITLE
Support OID dot notation as input for rekor-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ jobs:
         fulcioExtensions:
           build-config-uri:
             - https://example.com/owner/repository/build-config.yml
+        customExtensions:
+          - objectIdentifier: 1.3.6.1.4.1.57264.1.9
+            extensionValues: https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0
 ```
 
 In this example, the monitor will log:
@@ -93,6 +96,7 @@ In this example, the monitor will log:
 * Non-certificate entries, such as PGP or SSH keys, whose subject matches `subject@domain.com`
 * Entries whose key or certificate fingerprint matches `A0B1C2D3E4F5`
 * Entries that contain a certificate with a Build Config URI Extension matching `https://example.com/owner/repository/build-config.yml`
+* Entries that contain a certificate with OID extension `1.3.6.1.4.1.57264.1.9` (Fulcio OID for Build Signer URI) and an extension value matching `https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.4.0`
 
 Fingerprint values are as follows:
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -14,10 +14,42 @@
 
 package identity
 
-import "encoding/asn1"
+import (
+	"encoding/asn1"
+	"errors"
+	"strconv"
+	"strings"
+)
 
 // OIDMatcher holds an OID field and a list of values to match on
 type OIDMatcher struct {
 	ObjectIdentifier asn1.ObjectIdentifier `yaml:"objectIdentifier"`
 	ExtensionValues  []string              `yaml:"extensionValues"`
+}
+
+// CustomOID holds an OID field represented in dot notation and a list of values to match on
+type CustomExtension struct {
+	ObjectIdentifier string   `yaml:"objectIdentifier"`
+	ExtensionValues  []string `yaml:"extensionValues"`
+}
+
+// ParseObjectIdentifier parses a string representing an ObjectIdentifier in dot notation
+// and converts it into an asn1.ObjectIdentiifer.
+func ParseObjectIdentifier(oid string) (asn1.ObjectIdentifier, error) {
+	if len(oid) == 0 {
+		return nil, errors.New("could not parse object identifier: empty input")
+	}
+	nodes := strings.Split(oid, ".")
+	objectIdentifier := make([]int, len(nodes))
+	for i, node := range nodes {
+		if strings.TrimSpace(node) == "" {
+			return nil, errors.New("could not parse object identifier: no characters between two dots")
+		}
+		intNode, err := strconv.Atoi(node)
+		if err != nil {
+			return nil, err
+		}
+		objectIdentifier[i] = intNode
+	}
+	return asn1.ObjectIdentifier(objectIdentifier), nil
 }

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package identity
+
+import (
+	"testing"
+)
+
+// test ParseObjectIdentifier
+func TestParseObjectIdentifier(t *testing.T) {
+	oid, err := ParseObjectIdentifier("")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier(".")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("....")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("a.a")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("1.")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("1.1.5.6.7.8..")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier(".1.1.5.67.8")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	_, err = ParseObjectIdentifier("1")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+
+	_, err = ParseObjectIdentifier("1.4.1.5")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+
+	_, err = ParseObjectIdentifier("11254215212.4.123.54.1.622")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+}

--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -1027,59 +1027,6 @@ func TestMergeOIDMatchers(t *testing.T) {
 	}
 }
 
-// test parseObjectIdentifier
-func TestParseObjectIdentifier(t *testing.T) {
-	oid, err := identity.ParseObjectIdentifier("")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier(".")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier("....")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier("a.a")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier("1.")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier("1.1.5.6.7.8..")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = identity.ParseObjectIdentifier(".1.1.5.67.8")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	_, err = identity.ParseObjectIdentifier("1")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
-	}
-
-	_, err = identity.ParseObjectIdentifier("1.4.1.5")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
-	}
-
-	_, err = identity.ParseObjectIdentifier("11254215212.4.123.54.1.622")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
-	}
-}
-
 // test renderFulcioOIDMatchers
 func TestRenderFulcioOIDMatchers(t *testing.T) {
 	extValueString := "test cert value"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR adds support for OID extension monitoring via manual input through dot notation of object identifiers. Users can input any OID extension through dot notation within the CLI or GitHub Actions reusable monitoring workflow. This is intended to make it easier for users to monitor OIDs through the CLI or GitHub Actions reusable monitoring workflow.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Custom OIDs are supported as arguments within the CLI or GitHub Actions reusable monitoring workflow as part of the yaml string that is passed in as an argument.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

The rekor-monitor README has been updated accordingly to reflect the support of these new arguments.