### PR TITLE
extending identity entry fields to add OID extension and value

### DIFF
--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -83,7 +83,7 @@ type MonitoredValues struct {
 	OIDMatchers []OIDMatcher `yaml:"oidMatchers"`
 }
 
-// IdentityEntry holds a certificate subject, issuer, and log entry metadata
+// IdentityEntry holds a certificate subject, issuer, OID extension and associated value, and log entry metadata
 type IdentityEntry struct {
 	CertSubject    string
 	Issuer         string
@@ -97,7 +97,7 @@ type IdentityEntry struct {
 
 func (e *IdentityEntry) String() string {
 	var parts []string
-	for _, s := range []string{e.CertSubject, e.Issuer, e.Fingerprint, e.Subject, strconv.Itoa(int(e.Index)), e.UUID} {
+	for _, s := range []string{e.CertSubject, e.Issuer, e.Fingerprint, e.Subject, strconv.Itoa(int(e.Index)), e.UUID, e.OIDExtension.String(), e.ExtensionValue} {
 		if strings.TrimSpace(s) != "" {
 			parts = append(parts, s)
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR extends the IdentityEntry struct to add fields for an OID extension and matching value, if a log entry was matched on from an OID extension/value pair. This PR lays the groundwork for OID monitoring support laid out in [this doc](https://docs.google.com/document/d/1YcC31YmnCSwL1GRbC7LSor-YY6qhk3ynMhN1UNT-Wyw/edit?usp=sharing&resourcekey=0-OoutF_Qh1Q5q0p4ZPYXncA).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

None

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Updated documentation will be done accordingly in stacked PRs which implement API changes.
