### PR TITLE
refactor extensions and identity packages

### DIFF
--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/rekor"
 	"github.com/sigstore/rekor-monitor/pkg/util/file"
 	"github.com/sigstore/rekor/pkg/client"
@@ -46,7 +47,7 @@ const (
 )
 
 // runConsistencyCheck periodically verifies the root hash consistency of a Rekor log.
-func runConsistencyCheck(interval *time.Duration, rekorClient *gclient.Rekor, verifier signature.Verifier, logInfoFile *string, mvs rekor.MonitoredValues, outputIdentitiesFile *string, once *bool) error {
+func runConsistencyCheck(interval *time.Duration, rekorClient *gclient.Rekor, verifier signature.Verifier, logInfoFile *string, mvs identity.MonitoredValues, outputIdentitiesFile *string, once *bool) error {
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
 
@@ -158,7 +159,7 @@ func main() {
 	userAgentString := flag.String("user-agent", "", "details to include in the user agent string")
 	flag.Parse()
 
-	var monitoredVals rekor.MonitoredValues
+	var monitoredVals identity.MonitoredValues
 	if err := yaml.Unmarshal([]byte(*monitoredValsInput), &monitoredVals); err != nil {
 		log.Fatalf("error parsing identities: %v", err)
 	}

--- a/pkg/fulcio/extensions/extensions_test.go
+++ b/pkg/fulcio/extensions/extensions_test.go
@@ -1,0 +1,180 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions
+
+import (
+	"encoding/asn1"
+	"testing"
+)
+
+// Test mergeOIDMatchers
+func TestMergeOIDMatchers(t *testing.T) {
+	oidMatchers, err := MergeOIDMatchers([]OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{},
+	}}, FulcioExtensions{}, []CustomExtension{})
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if len(oidMatchers) != 1 {
+		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	}
+
+	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{""},
+	}}, FulcioExtensions{}, []CustomExtension{})
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if len(oidMatchers) != 1 {
+		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	}
+
+	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{"test", "test2"},
+	}}, FulcioExtensions{}, []CustomExtension{})
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if len(oidMatchers) != 1 {
+		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	}
+
+	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{"test1"},
+	}, {
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{"test"},
+	}}, FulcioExtensions{}, []CustomExtension{})
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if len(oidMatchers) != 1 {
+		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	}
+
+	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+		ExtensionValues:  []string{"test1"},
+	}, {
+		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 18},
+		ExtensionValues:  []string{"test"},
+	}}, FulcioExtensions{}, []CustomExtension{})
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+	if len(oidMatchers) != 2 {
+		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	}
+}
+
+// test ParseObjectIdentifier
+func TestParseObjectIdentifier(t *testing.T) {
+	oid, err := ParseObjectIdentifier("")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier(".")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("....")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("a.a")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("1.")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier("1.1.5.6.7.8..")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	oid, err = ParseObjectIdentifier(".1.1.5.67.8")
+	if err == nil {
+		t.Errorf("Expected error, got nil and oid %s", oid)
+	}
+
+	_, err = ParseObjectIdentifier("1")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+
+	_, err = ParseObjectIdentifier("1.4.1.5")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+
+	_, err = ParseObjectIdentifier("11254215212.4.123.54.1.622")
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+}
+
+// test renderFulcioOIDMatchers
+func TestRenderFulcioOIDMatchers(t *testing.T) {
+	extValueString := "test cert value"
+	fulcioExtensions := FulcioExtensions{
+		BuildSignerURI: []string{extValueString},
+		BuildConfigURI: []string{"1", "2", "3", "4", "5", "6"},
+	}
+
+	renderedFulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
+	if err != nil {
+		t.Errorf("expected nil, received error %v", err)
+	}
+
+	if len(renderedFulcioOIDMatchers) != 2 {
+		t.Errorf("expected OIDMatchers to have length 2, received length %d", len(renderedFulcioOIDMatchers))
+	}
+
+	buildSignerURIMatcher := renderedFulcioOIDMatchers[0]
+	buildSignerURIMatcherOID := buildSignerURIMatcher.ObjectIdentifier
+	buildSignerURIMatcherExtValues := buildSignerURIMatcher.ExtensionValues
+	if !buildSignerURIMatcherOID.Equal(OIDBuildSignerURI) {
+		t.Errorf("expected OIDMatcher to be BuildSignerURI 1.3.6.1.4.1.57264.1.9, received %s", buildSignerURIMatcherOID)
+	}
+	if len(buildSignerURIMatcherExtValues) != 1 {
+		t.Errorf("expected BuildSignerURI extension values to have length 1, received %d", len(buildSignerURIMatcherExtValues))
+	}
+	buildSignerURIMatcherExtValue := buildSignerURIMatcherExtValues[0]
+	if buildSignerURIMatcherExtValue != extValueString {
+		t.Errorf("expected BuildSignerURI extension value to be 'test cert value', received %s", buildSignerURIMatcherExtValue)
+	}
+
+	buildConfigURIMatcher := renderedFulcioOIDMatchers[1]
+	buildConfigURIMatcherOID := buildConfigURIMatcher.ObjectIdentifier
+	buildConfigURIMatcherExtValues := buildConfigURIMatcher.ExtensionValues
+	if !buildConfigURIMatcherOID.Equal(OIDBuildConfigURI) {
+		t.Errorf("expected OIDMatcher to be BuildConfigURI 1.3.6.1.4.1.57264.1.18, received %s", buildConfigURIMatcherOID)
+	}
+
+	if len(buildConfigURIMatcherExtValues) != 6 {
+		t.Errorf("expected BuildConfigURI extension values to have length 6, received %d", len(buildConfigURIMatcherExtValues))
+	}
+}

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -18,55 +18,16 @@ import (
 	"testing"
 )
 
-// test ParseObjectIdentifier
-func TestParseObjectIdentifier(t *testing.T) {
-	oid, err := ParseObjectIdentifier("")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
+// Test RekorLogEntry.String()
+func TestIdentityEntryString(t *testing.T) {
+	identityEntry := RekorLogEntry{
+		CertSubject: "test-cert-subject",
+		UUID:        "test-uuid",
+		Index:       1,
 	}
-
-	oid, err = ParseObjectIdentifier(".")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = ParseObjectIdentifier("....")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = ParseObjectIdentifier("a.a")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = ParseObjectIdentifier("1.")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = ParseObjectIdentifier("1.1.5.6.7.8..")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	oid, err = ParseObjectIdentifier(".1.1.5.67.8")
-	if err == nil {
-		t.Errorf("Expected error, got nil and oid %s", oid)
-	}
-
-	_, err = ParseObjectIdentifier("1")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
-	}
-
-	_, err = ParseObjectIdentifier("1.4.1.5")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
-	}
-
-	_, err = ParseObjectIdentifier("11254215212.4.123.54.1.622")
-	if err != nil {
-		t.Errorf("Expected nil, got error %v", err)
+	identityEntryString := identityEntry.String()
+	expectedIdentityEntryString := "test-cert-subject 1 test-uuid"
+	if identityEntryString != expectedIdentityEntryString {
+		t.Errorf("expected %s, received %s", expectedIdentityEntryString, identityEntryString)
 	}
 }

--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -92,8 +92,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
 			},
@@ -118,8 +118,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// match to subject and issuer with certificate in hashedrekord
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
 				Issuers:     []string{issuer},
@@ -133,8 +133,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// match with regex subject and regex issuer with certificate in hashedrekord
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: ".*ubje.*",
 				Issuers:     []string{".+@domain.com"},
@@ -177,8 +177,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		}
 		logEntry := models.LogEntry{uuid: logEntryAnon}
 
-		matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-			CertificateIdentities: []CertificateIdentity{
+		matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+			CertificateIdentities: []identity.CertificateIdentity{
 				{
 					CertSubject: ".*ubje.*",
 					Issuers:     []string{".+@domain.com"},
@@ -193,8 +193,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// no match with same subject, other issuer
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
 				Issuers:     []string{"other"},
@@ -208,8 +208,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// no match with different subject
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: "other",
 			},
@@ -273,8 +273,8 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CertificateIdentities: []CertificateIdentity{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
 				Issuers:     []string{issuer},
@@ -351,7 +351,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	fp := hex.EncodeToString(digest[:])
 
 	//  match to key fingerprint in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Fingerprints: []string{
 			fp,
 		}})
@@ -372,7 +372,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 
 	// no match with different fingerprints
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Fingerprints: []string{
 			"other-fp",
 		}})
@@ -433,7 +433,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Subjects: []string{
 			subject,
 		}})
@@ -454,7 +454,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 
 	// no match with different subjects
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Subjects: []string{
 			"other-sub",
 		}})
@@ -527,8 +527,8 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		OIDMatchers: []identity.OIDMatcher{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		OIDMatchers: []extensions.OIDMatcher{
 			{
 				ObjectIdentifier: oid,
 				ExtensionValues:  []string{extValueString},
@@ -548,8 +548,8 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different extension value
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		OIDMatchers: []identity.OIDMatcher{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		OIDMatchers: []extensions.OIDMatcher{
 			{
 				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
 				ExtensionValues:  []string{"wrong"},
@@ -563,8 +563,8 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different oid extension field
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		OIDMatchers: []identity.OIDMatcher{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		OIDMatchers: []extensions.OIDMatcher{
 			{
 				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 14},
 				ExtensionValues:  []string{"test cert value"},
@@ -639,7 +639,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		FulcioExtensions: extensions.FulcioExtensions{
 			BuildSignerURI: []string{extValueString},
 		}})
@@ -657,8 +657,8 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different extension value
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		OIDMatchers: []identity.OIDMatcher{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		OIDMatchers: []extensions.OIDMatcher{
 			{
 				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
 				ExtensionValues:  []string{"wrong"},
@@ -672,7 +672,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different oid extension field
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		FulcioExtensions: extensions.FulcioExtensions{
 			BuildSignerDigest: []string{extValueString},
 		}})
@@ -745,8 +745,8 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CustomExtensions: []identity.CustomExtension{
+	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CustomExtensions: []extensions.CustomExtension{
 			{
 				ObjectIdentifier: "1.3.6.1.4.1.57264.1.9",
 				ExtensionValues:  []string{extValueString},
@@ -766,8 +766,8 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different extension value
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CustomExtensions: []identity.CustomExtension{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CustomExtensions: []extensions.CustomExtension{
 			{
 				ObjectIdentifier: "1.3.6.1.4.1.57264.1.9",
 				ExtensionValues:  []string{"wrong"},
@@ -781,8 +781,8 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	}
 
 	// no match to oid with different oid extension field
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, MonitoredValues{
-		CustomExtensions: []identity.CustomExtension{
+	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		CustomExtensions: []extensions.CustomExtension{
 			{
 				ObjectIdentifier: "1.3.6.1.4.1.57264.1.16",
 				ExtensionValues:  []string{extValueString},
@@ -798,13 +798,13 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 
 func TestMatchedIndicesFailures(t *testing.T) {
 	// failure: no monitored values
-	_, err := MatchedIndices(nil, MonitoredValues{})
+	_, err := MatchedIndices(nil, identity.MonitoredValues{})
 	if err == nil || !strings.Contains(err.Error(), "no identities provided to monitor") {
 		t.Fatalf("expected error with no identities, got %v", err)
 	}
 
 	// failure: certificate subject empty
-	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err = MatchedIndices(nil, identity.MonitoredValues{CertificateIdentities: []identity.CertificateIdentity{
 		{
 			CertSubject: "",
 		},
@@ -814,7 +814,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	}
 
 	// failure: issuer empty
-	_, err = MatchedIndices(nil, MonitoredValues{CertificateIdentities: []CertificateIdentity{
+	_, err = MatchedIndices(nil, identity.MonitoredValues{CertificateIdentities: []identity.CertificateIdentity{
 		{
 			CertSubject: "s",
 			Issuers:     []string{""},
@@ -825,19 +825,19 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	}
 
 	// failure: subject empty
-	_, err = MatchedIndices(nil, MonitoredValues{Subjects: []string{""}})
+	_, err = MatchedIndices(nil, identity.MonitoredValues{Subjects: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "subject empty") {
 		t.Fatalf("expected error with empty subject, got %v", err)
 	}
 
 	// failure: fingerprint empty
-	_, err = MatchedIndices(nil, MonitoredValues{Fingerprints: []string{""}})
+	_, err = MatchedIndices(nil, identity.MonitoredValues{Fingerprints: []string{""}})
 	if err == nil || !strings.Contains(err.Error(), "fingerprint empty") {
 		t.Fatalf("expected error with empty fingerprint, got %v", err)
 	}
 
 	// failure: oid extension empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{},
 		ExtensionValues:  []string{""},
 	}}})
@@ -846,7 +846,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	}
 
 	// failure: oid matched values list empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{},
 	}}})
@@ -855,7 +855,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 	}
 
 	// failure: oid matched value string empty
-	_, err = MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{""},
 	}}})
@@ -866,7 +866,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 
 func TestMatchedIndicesFailuresOIDExtensionEmpty(t *testing.T) {
 	// failure: oid extension empty
-	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{},
 		ExtensionValues:  []string{""},
 	}}})
@@ -877,7 +877,7 @@ func TestMatchedIndicesFailuresOIDExtensionEmpty(t *testing.T) {
 
 func TestMatchedIndicesFailuresOIDExtensionValuesEmpty(t *testing.T) {
 	// failure: oid extension values list empty
-	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{},
 	}}})
@@ -888,7 +888,7 @@ func TestMatchedIndicesFailuresOIDExtensionValuesEmpty(t *testing.T) {
 
 func TestMatchedIndicesFailuresOIDExtensionValueEmpty(t *testing.T) {
 	// failure: oid extension value string empty
-	_, err := MatchedIndices(nil, MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
+	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 		ExtensionValues:  []string{""},
 	}}})
@@ -960,112 +960,5 @@ func TestOIDMatchesValue(t *testing.T) {
 	}
 	if extValue != extValueString {
 		t.Errorf("Expected string to equal 'test cert value', got %s", extValue)
-	}
-}
-
-// Test mergeOIDMatchers
-func TestMergeOIDMatchers(t *testing.T) {
-	oidMatchers, err := mergeOIDMatchers(MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{},
-	}}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = mergeOIDMatchers(MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{""},
-	}}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = mergeOIDMatchers(MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test", "test2"},
-	}}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = mergeOIDMatchers(MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test1"},
-	}, {
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test"},
-	}}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = mergeOIDMatchers(MonitoredValues{OIDMatchers: []identity.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test1"},
-	}, {
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 18},
-		ExtensionValues:  []string{"test"},
-	}}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 2 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-}
-
-// test renderFulcioOIDMatchers
-func TestRenderFulcioOIDMatchers(t *testing.T) {
-	extValueString := "test cert value"
-	fulcioExtensions := extensions.FulcioExtensions{
-		BuildSignerURI: []string{extValueString},
-		BuildConfigURI: []string{"1", "2", "3", "4", "5", "6"},
-	}
-
-	renderedFulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
-	if err != nil {
-		t.Errorf("expected nil, received error %v", err)
-	}
-
-	if len(renderedFulcioOIDMatchers) != 2 {
-		t.Errorf("expected OIDMatchers to have length 2, received length %d", len(renderedFulcioOIDMatchers))
-	}
-
-	buildSignerURIMatcher := renderedFulcioOIDMatchers[0]
-	buildSignerURIMatcherOID := buildSignerURIMatcher.ObjectIdentifier
-	buildSignerURIMatcherExtValues := buildSignerURIMatcher.ExtensionValues
-	if !buildSignerURIMatcherOID.Equal(extensions.OIDBuildSignerURI) {
-		t.Errorf("expected OIDMatcher to be BuildSignerURI 1.3.6.1.4.1.57264.1.9, received %s", buildSignerURIMatcherOID)
-	}
-	if len(buildSignerURIMatcherExtValues) != 1 {
-		t.Errorf("expected BuildSignerURI extension values to have length 1, received %d", len(buildSignerURIMatcherExtValues))
-	}
-	buildSignerURIMatcherExtValue := buildSignerURIMatcherExtValues[0]
-	if buildSignerURIMatcherExtValue != extValueString {
-		t.Errorf("expected BuildSignerURI extension value to be 'test cert value', received %s", buildSignerURIMatcherExtValue)
-	}
-
-	buildConfigURIMatcher := renderedFulcioOIDMatchers[1]
-	buildConfigURIMatcherOID := buildConfigURIMatcher.ObjectIdentifier
-	buildConfigURIMatcherExtValues := buildConfigURIMatcher.ExtensionValues
-	if !buildConfigURIMatcherOID.Equal(extensions.OIDBuildConfigURI) {
-		t.Errorf("expected OIDMatcher to be BuildConfigURI 1.3.6.1.4.1.57264.1.18, received %s", buildConfigURIMatcherOID)
-	}
-
-	if len(buildConfigURIMatcherExtValues) != 6 {
-		t.Errorf("expected BuildConfigURI extension values to have length 6, received %d", len(buildConfigURIMatcherExtValues))
 	}
 }

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/sigstore/rekor-monitor/pkg/rekor"
+	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor/pkg/util"
 )
 
@@ -118,7 +118,7 @@ func DeleteOldCheckpoints(logInfoFile string) error {
 }
 
 // WriteIdentity writes an identity found in the log to a file
-func WriteIdentity(idFile string, idEntry rekor.IdentityEntry) error {
+func WriteIdentity(idFile string, idEntry identity.RekorLogEntry) error {
 	file, err := os.OpenFile(idFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open identities file: %w", err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR refactors the `extensions`, `pkg/identity`, and `pkg/rekor` packages to move structs around OID extensions and rekor identities into more suitable respective packages, in the goal that `pkg/rekor/identity` doesn't suffer from bloating, and building more features out of rekor-monitor is easier in terms of splitting work into separate packages (ex. future work on expanding found identity notification and notification platforms will be easier to place in its own `notification` package).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
