### PR TITLE
increase coverage inside pkg/extensions

### DIFF
--- a/pkg/fulcio/extensions/extensions_test.go
+++ b/pkg/fulcio/extensions/extensions_test.go
@@ -74,12 +74,17 @@ func TestMergeOIDMatchers(t *testing.T) {
 	}, {
 		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 18},
 		ExtensionValues:  []string{"test"},
-	}}, FulcioExtensions{}, []CustomExtension{})
+	}}, FulcioExtensions{
+		BuildConfigDigest: []string{"test"},
+	}, []CustomExtension{{
+		ObjectIdentifier: "2.5.29.16",
+		ExtensionValues:  []string{"test"},
+	}})
 	if err != nil {
 		t.Errorf("Expected nil, got %v", err)
 	}
-	if len(oidMatchers) != 2 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+	if len(oidMatchers) != 4 {
+		t.Errorf("Expected 4 OIDMatchers, got %d", len(oidMatchers))
 	}
 }
 
@@ -176,5 +181,40 @@ func TestRenderFulcioOIDMatchers(t *testing.T) {
 
 	if len(buildConfigURIMatcherExtValues) != 6 {
 		t.Errorf("expected BuildConfigURI extension values to have length 6, received %d", len(buildConfigURIMatcherExtValues))
+	}
+}
+
+func TestRenderFulcioOIDMatchersAllFields(t *testing.T) {
+	testValueString := "test"
+	fulcioExtensions := FulcioExtensions{
+		Issuer:                              []string{testValueString},
+		GithubWorkflowTrigger:               []string{testValueString},
+		GithubWorkflowSHA:                   []string{testValueString},
+		GithubWorkflowName:                  []string{testValueString},
+		GithubWorkflowRepository:            []string{testValueString},
+		GithubWorkflowRef:                   []string{testValueString},
+		BuildSignerURI:                      []string{testValueString},
+		BuildConfigURI:                      []string{testValueString},
+		BuildSignerDigest:                   []string{testValueString},
+		RunnerEnvironment:                   []string{testValueString},
+		SourceRepositoryURI:                 []string{testValueString},
+		SourceRepositoryDigest:              []string{testValueString},
+		SourceRepositoryIdentifier:          []string{testValueString},
+		SourceRepositoryRef:                 []string{testValueString},
+		SourceRepositoryOwnerURI:            []string{testValueString},
+		SourceRepositoryOwnerIdentifier:     []string{testValueString},
+		SourceRepositoryVisibilityAtSigning: []string{testValueString},
+		BuildConfigDigest:                   []string{testValueString},
+		BuildTrigger:                        []string{testValueString},
+		RunInvocationURI:                    []string{testValueString},
+	}
+
+	renderedFulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
+	if err != nil {
+		t.Errorf("expected nil, received error %v", err)
+	}
+
+	if len(renderedFulcioOIDMatchers) != 21 {
+		t.Errorf("expected OIDMatchers to have length 21, received length %d", len(renderedFulcioOIDMatchers))
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR increases test coverage within `pkg/extensions` by rendering all OID extensions inside `RenderFulcioOIDMatchers` and increasing coverage within `MergeOIDMatchers`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
