### PR TITLE
Refactor tests to be table-driven

### DIFF
--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -192,33 +192,31 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		}
 	}
 
-	// no match with same subject, other issuer
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		CertificateIdentities: []identity.CertificateIdentity{
-			{
-				CertSubject: subject,
-				Issuers:     []string{"other"},
+	testedMonitoredValues := []identity.MonitoredValues{
+		{
+			CertificateIdentities: []identity.CertificateIdentity{
+				{
+					CertSubject: subject,
+					Issuers:     []string{"other"},
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected error matching IDs, got %v", err)
-	}
-	if len(matches) != 0 {
-		t.Fatalf("expected 0 matches, got %d", len(matches))
-	}
-
-	// no match with different subject
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		CertificateIdentities: []identity.CertificateIdentity{
-			{
-				CertSubject: "other",
+		},
+		{
+			CertificateIdentities: []identity.CertificateIdentity{
+				{
+					CertSubject: "other",
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected error matching IDs, got %v", err)
+		},
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected 0 matches, got %d", len(matches))
+	for _, monitoredValues := range testedMonitoredValues {
+		matches, err := MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
+		if err != nil {
+			t.Fatalf("expected error matching IDs, got %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("expected 0 matches, got %d", len(matches))
+		}
 	}
 }
 
@@ -547,34 +545,32 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
 	}
 
-	// no match to oid with different extension value
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		OIDMatchers: []extensions.OIDMatcher{
-			{
-				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
-				ExtensionValues:  []string{"wrong"},
+	testedMonitoredValues := []identity.MonitoredValues{
+		{
+			OIDMatchers: []extensions.OIDMatcher{
+				{
+					ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
+					ExtensionValues:  []string{"wrong"},
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
-	}
-
-	// no match to oid with different oid extension field
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		OIDMatchers: []extensions.OIDMatcher{
-			{
-				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 14},
-				ExtensionValues:  []string{"test cert value"},
+		},
+		{
+			OIDMatchers: []extensions.OIDMatcher{
+				{
+					ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 14},
+					ExtensionValues:  []string{"test cert value"},
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+		},
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
+	for _, monitoredValues := range testedMonitoredValues {
+		matches, err = MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("expected no matches, got %d", len(matches))
+		}
 	}
 }
 
@@ -765,135 +761,108 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
 	}
 
-	// no match to oid with different extension value
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		CustomExtensions: []extensions.CustomExtension{
-			{
-				ObjectIdentifier: "1.3.6.1.4.1.57264.1.9",
-				ExtensionValues:  []string{"wrong"},
+	testedMonitoredValues := []identity.MonitoredValues{
+		{
+			CustomExtensions: []extensions.CustomExtension{
+				{
+					ObjectIdentifier: "1.3.6.1.4.1.57264.1.9",
+					ExtensionValues:  []string{"wrong"},
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
-	}
-
-	// no match to oid with different oid extension field
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		CustomExtensions: []extensions.CustomExtension{
-			{
-				ObjectIdentifier: "1.3.6.1.4.1.57264.1.16",
-				ExtensionValues:  []string{extValueString},
+		},
+		{
+			CustomExtensions: []extensions.CustomExtension{
+				{
+					ObjectIdentifier: "1.3.6.1.4.1.57264.1.16",
+					ExtensionValues:  []string{extValueString},
+				},
 			},
-		}})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+		},
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
+	for _, monitoredValues := range testedMonitoredValues {
+		matches, err = MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("expected no matches, got %d", len(matches))
+		}
 	}
 }
 
 func TestMatchedIndicesFailures(t *testing.T) {
-	// failure: no monitored values
-	_, err := MatchedIndices(nil, identity.MonitoredValues{})
-	if err == nil || !strings.Contains(err.Error(), "no identities provided to monitor") {
-		t.Fatalf("expected error with no identities, got %v", err)
-	}
-
-	// failure: certificate subject empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{CertificateIdentities: []identity.CertificateIdentity{
-		{
-			CertSubject: "",
+	monitoredValuesTests := map[string]struct {
+		input       identity.MonitoredValues
+		errorString string
+	}{
+		"no monitored values": {
+			input:       identity.MonitoredValues{},
+			errorString: "no identities provided to monitor",
 		},
-	}})
-	if err == nil || !strings.Contains(err.Error(), "certificate subject empty") {
-		t.Fatalf("expected error with empty cert subject, got %v", err)
-	}
-
-	// failure: issuer empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{CertificateIdentities: []identity.CertificateIdentity{
-		{
-			CertSubject: "s",
-			Issuers:     []string{""},
+		"cert subject empty": {
+			input: identity.MonitoredValues{
+				CertificateIdentities: []identity.CertificateIdentity{
+					{
+						CertSubject: "",
+					},
+				},
+			},
+			errorString: "certificate subject empty",
 		},
-	}})
-	if err == nil || !strings.Contains(err.Error(), "issuer empty") {
-		t.Fatalf("expected error with empty issuer, got %v", err)
+		"empty issuer": {
+			input: identity.MonitoredValues{CertificateIdentities: []identity.CertificateIdentity{
+				{
+					CertSubject: "s",
+					Issuers:     []string{""},
+				},
+			}},
+			errorString: "issuer empty",
+		},
+		"empty subject": {
+			input:       identity.MonitoredValues{Subjects: []string{""}},
+			errorString: "subject empty",
+		},
+		"empty fingerprint": {
+			input:       identity.MonitoredValues{Fingerprints: []string{""}},
+			errorString: "fingerprint empty",
+		},
+		"empty oid extension": {
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+				ObjectIdentifier: asn1.ObjectIdentifier{},
+				ExtensionValues:  []string{""},
+			}}},
+			errorString: "could not parse object identifier: empty input",
+		},
+		"empty oid matched values": {
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+				ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+				ExtensionValues:  []string{},
+			}}},
+			errorString: "oid matched values empty",
+		},
+		"empty oid matched value": {
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+				ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+				ExtensionValues:  []string{""},
+			}}},
+			errorString: "oid matched value empty",
+		},
+		"empty oid field": {
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+				ObjectIdentifier: asn1.ObjectIdentifier{},
+				ExtensionValues:  []string{""},
+			}}},
+			errorString: "could not parse object identifier: empty input",
+		},
 	}
 
-	// failure: subject empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{Subjects: []string{""}})
-	if err == nil || !strings.Contains(err.Error(), "subject empty") {
-		t.Fatalf("expected error with empty subject, got %v", err)
-	}
-
-	// failure: fingerprint empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{Fingerprints: []string{""}})
-	if err == nil || !strings.Contains(err.Error(), "fingerprint empty") {
-		t.Fatalf("expected error with empty fingerprint, got %v", err)
-	}
-
-	// failure: oid extension empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{},
-		ExtensionValues:  []string{""},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "could not parse object identifier: empty input") {
-		t.Fatalf("expected error with empty oid extension, got %v", err)
-	}
-
-	// failure: oid matched values list empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "oid matched values empty") {
-		t.Fatalf("expected error with empty oid matched values list, got %v", err)
-	}
-
-	// failure: oid matched value string empty
-	_, err = MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{""},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "oid matched value empty") {
-		t.Fatalf("expected error with empty oid matched value string, got %v", err)
-	}
-}
-
-func TestMatchedIndicesFailuresOIDExtensionEmpty(t *testing.T) {
-	// failure: oid extension empty
-	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{},
-		ExtensionValues:  []string{""},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "could not parse object identifier: empty input") {
-		t.Fatalf("expected error with empty oid extension, got %v", err)
-	}
-}
-
-func TestMatchedIndicesFailuresOIDExtensionValuesEmpty(t *testing.T) {
-	// failure: oid extension values list empty
-	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "oid matched values empty") {
-		t.Fatalf("expected error with empty oid matched values list, got %v", err)
-	}
-}
-
-func TestMatchedIndicesFailuresOIDExtensionValueEmpty(t *testing.T) {
-	// failure: oid extension value string empty
-	_, err := MatchedIndices(nil, identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{""},
-	}}})
-	if err == nil || !strings.Contains(err.Error(), "oid matched value empty") {
-		t.Fatalf("expected error with empty oid matched value string, got %v", err)
+	for name, testCase := range monitoredValuesTests {
+		t.Run(name, func(t *testing.T) {
+			_, err := MatchedIndices(nil, testCase.input)
+			if err == nil || !strings.Contains(err.Error(), testCase.errorString) {
+				t.Fatalf("expected error %v, received %v", testCase.errorString, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR refactors various tests within rekor-monitor (`identity_tests.go` and `extension_tests.go`) to use [table-driven testing principles](https://dave.cheney.net/2019/05/07/prefer-table-driven-tests), as part of work outlined [in this document](https://docs.google.com/document/d/15XEwkUDy2Wp9oSpazD18vMMbeo-UDpqpzPAiiMkGvFk/edit?resourcekey=0-l0iCV7L2HCa8xC3XCEz8rg&tab=t.0). It also removes some redundant/duplicated test cases.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
