### PR TITLE
mock createLogEntry, getLogProof

### DIFF
--- a/pkg/rekor/mock/mock_rekor_client.go
+++ b/pkg/rekor/mock/mock_rekor_client.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/strfmt"
 
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/client/pubkey"
@@ -32,16 +31,16 @@ import (
 // mClient.Entries = &mock.EntriesClient{Entries: <logEntries>, ETag: <etag>, Location: <location>, LogEntry: <logEntry>}
 type EntriesClient struct {
 	Entries  []*models.LogEntry
-	ETag     string
-	Location strfmt.URI
 	LogEntry models.LogEntry
+	Error    error
 }
 
 func (m *EntriesClient) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries.ClientOption) (*entries.CreateLogEntryCreated, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
 	return &entries.CreateLogEntryCreated{
-		ETag:     m.ETag,
-		Location: m.Location,
-		Payload:  m.LogEntry,
+		Payload: m.LogEntry,
 	}, nil
 }
 
@@ -54,6 +53,9 @@ func (m *EntriesClient) GetLogEntryByUUID(_ *entries.GetLogEntryByUUIDParams, _ 
 }
 
 func (m *EntriesClient) SearchLogQuery(params *entries.SearchLogQueryParams, _ ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
 	resp := []models.LogEntry{}
 	if m.Entries != nil {
 		for _, i := range params.Entry.LogIndexes {
@@ -74,15 +76,22 @@ func (m *EntriesClient) SetTransport(_ runtime.ClientTransport) {}
 type TlogClient struct {
 	LogInfo          *models.LogInfo
 	ConsistencyProof *models.ConsistencyProof
+	Error            error
 }
 
 func (m *TlogClient) GetLogInfo(_ *tlog.GetLogInfoParams, _ ...tlog.ClientOption) (*tlog.GetLogInfoOK, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
 	return &tlog.GetLogInfoOK{
 		Payload: m.LogInfo,
 	}, nil
 }
 
 func (m *TlogClient) GetLogProof(_ *tlog.GetLogProofParams, _ ...tlog.ClientOption) (*tlog.GetLogProofOK, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
 	return &tlog.GetLogProofOK{
 		Payload: m.ConsistencyProof,
 	}, nil

--- a/pkg/rekor/mock/mock_rekor_client.go
+++ b/pkg/rekor/mock/mock_rekor_client.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
 
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/client/pubkey"
@@ -28,13 +29,20 @@ import (
 // EntriesClient is a client that implements entries.ClientService for Rekor
 // To use:
 // var mClient client.Rekor
-// mClient.Entries = &mock.EntriesClient{Entries: <logEntries>}
+// mClient.Entries = &mock.EntriesClient{Entries: <logEntries>, ETag: <etag>, Location: <location>, LogEntry: <logEntry>}
 type EntriesClient struct {
-	Entries []*models.LogEntry
+	Entries  []*models.LogEntry
+	ETag     string
+	Location strfmt.URI
+	LogEntry models.LogEntry
 }
 
 func (m *EntriesClient) CreateLogEntry(_ *entries.CreateLogEntryParams, _ ...entries.ClientOption) (*entries.CreateLogEntryCreated, error) {
-	return nil, errors.New("not implemented")
+	return &entries.CreateLogEntryCreated{
+		ETag:     m.ETag,
+		Location: m.Location,
+		Payload:  m.LogEntry,
+	}, nil
 }
 
 func (m *EntriesClient) GetLogEntryByIndex(_ *entries.GetLogEntryByIndexParams, _ ...entries.ClientOption) (*entries.GetLogEntryByIndexOK, error) {
@@ -62,9 +70,10 @@ func (m *EntriesClient) SetTransport(_ runtime.ClientTransport) {}
 // TlogClient is a client that implements tlog.ClientService for Rekor
 // To use:
 // var mClient client.Rekor
-// mClient.Entries = &mock.TlogClient{LogInfo: <loginfo>}
+// mClient.Entries = &mock.TlogClient{LogInfo: <loginfo>, ConsistencyProof: <consistencyproof>}
 type TlogClient struct {
-	LogInfo *models.LogInfo
+	LogInfo          *models.LogInfo
+	ConsistencyProof *models.ConsistencyProof
 }
 
 func (m *TlogClient) GetLogInfo(_ *tlog.GetLogInfoParams, _ ...tlog.ClientOption) (*tlog.GetLogInfoOK, error) {
@@ -74,7 +83,9 @@ func (m *TlogClient) GetLogInfo(_ *tlog.GetLogInfoParams, _ ...tlog.ClientOption
 }
 
 func (m *TlogClient) GetLogProof(_ *tlog.GetLogProofParams, _ ...tlog.ClientOption) (*tlog.GetLogProofOK, error) {
-	return nil, errors.New("not implemented")
+	return &tlog.GetLogProofOK{
+		Payload: m.ConsistencyProof,
+	}, nil
 }
 
 func (m *TlogClient) SetTransport(_ runtime.ClientTransport) {}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR mocks the CreateLogEntry and GetLogProof methods in the `mock_rekor_client` file, for use in future PRs to help unit test the reusable monitoring workflow which depends on the Rekor client. The mock Rekor client's EntriesClient and TlogClient can be instantiated with these new fields (return values for the CreateLogEntry and GetLogProof methods) if desired for mocking purposes. This PR also implements the ability to mock error return values in the case where error handling is desired to be tested.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
