### PR TITLE
Refactor monitoring workflow inputs

### DIFF
--- a/cmd/verifier/main.go
+++ b/cmd/verifier/main.go
@@ -83,7 +83,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = rekor.RunConsistencyCheck(interval, rekorClient, verifier, logInfoFile, monitoredVals, outputIdentitiesFile, once)
+	err = rekor.VerifyConsistencyCheckInputs(interval, logInfoFile, outputIdentitiesFile, once)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = rekor.RunConsistencyCheck(*interval, rekorClient, verifier, *logInfoFile, monitoredVals, *outputIdentitiesFile, *once)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -342,7 +342,7 @@ func oidMatchesPolicy(cert *x509.Certificate, oid asn1.ObjectIdentifier, extensi
 }
 
 // writeIdentitiesBetweenCheckpoints monitors for given identities between two checkpoints and writes any found identities to file.
-func writeIdentitiesBetweenCheckpoints(logInfo *models.LogInfo, prevCheckpoint *util.SignedCheckpoint, checkpoint *util.SignedCheckpoint, monitoredValues identity.MonitoredValues, rekorClient *client.Rekor, outputIdentitiesFile *string) error {
+func writeIdentitiesBetweenCheckpoints(logInfo *models.LogInfo, prevCheckpoint *util.SignedCheckpoint, checkpoint *util.SignedCheckpoint, monitoredValues identity.MonitoredValues, rekorClient *client.Rekor, outputIdentitiesFile string) error {
 	// Get log size of inactive shards
 	totalSize := 0
 	for _, s := range logInfo.InactiveShards {
@@ -366,7 +366,7 @@ func writeIdentitiesBetweenCheckpoints(logInfo *models.LogInfo, prevCheckpoint *
 			for _, idEntry := range idEntries {
 				fmt.Fprintf(os.Stderr, "Found %s\n", idEntry.String())
 
-				if err := file.WriteIdentity(*outputIdentitiesFile, idEntry); err != nil {
+				if err := file.WriteIdentity(outputIdentitiesFile, idEntry); err != nil {
 					return fmt.Errorf("failed to write entry: %v", err)
 				}
 			}

--- a/pkg/rekor/verifier_test.go
+++ b/pkg/rekor/verifier_test.go
@@ -19,7 +19,9 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/sigstore/rekor-monitor/pkg/rekor/mock"
 	"github.com/sigstore/rekor/pkg/generated/client"
@@ -45,5 +47,74 @@ func TestGetLogVerifier(t *testing.T) {
 	pubkey, _ := verifier.PublicKey()
 	if err := cryptoutils.EqualKeys(key.Public(), pubkey); err != nil {
 		t.Fatalf("expected equal keys: %v", err)
+	}
+}
+
+func TestVerifyConsistencyCheckInputs(t *testing.T) {
+	interval := 5 * time.Minute
+	logInfoFile := "./test/example_log_info_file_path.txt"
+	outputIdentitiesFile := "./test/example_output_identities_file.txt"
+	once := true
+	verifyConsistencyCheckInputTests := map[string]struct {
+		interval             *time.Duration
+		logInfoFile          *string
+		outputIdentitiesFile *string
+		once                 *bool
+		expectedError        error
+	}{
+		"successful verification": {
+			interval:             &interval,
+			logInfoFile:          &logInfoFile,
+			outputIdentitiesFile: &outputIdentitiesFile,
+			once:                 &once,
+			expectedError:        nil,
+		},
+		"fail --interval verification": {
+			interval:             nil,
+			logInfoFile:          &logInfoFile,
+			outputIdentitiesFile: &outputIdentitiesFile,
+			once:                 &once,
+			expectedError:        errors.New("--interval flag equal to nil"),
+		},
+		"fail --file verification": {
+			interval:             &interval,
+			logInfoFile:          nil,
+			outputIdentitiesFile: &outputIdentitiesFile,
+			once:                 &once,
+			expectedError:        errors.New("--file flag equal to nil"),
+		},
+		"fail --output-identities verification": {
+			interval:             &interval,
+			logInfoFile:          &logInfoFile,
+			outputIdentitiesFile: nil,
+			once:                 &once,
+			expectedError:        errors.New("--output-identities flag equal to nil"),
+		},
+		"fail --once verification": {
+			interval:             &interval,
+			logInfoFile:          &logInfoFile,
+			outputIdentitiesFile: &outputIdentitiesFile,
+			once:                 nil,
+			expectedError:        errors.New("--once flag equal to nil"),
+		},
+		"empty case": {
+			interval:             nil,
+			logInfoFile:          nil,
+			outputIdentitiesFile: nil,
+			once:                 nil,
+			expectedError:        errors.New("--interval flag equal to nil"),
+		},
+	}
+
+	for verifyConsistencyCheckInputTestCaseName, verifyConsistencyCheckInputTestCase := range verifyConsistencyCheckInputTests {
+		interval := verifyConsistencyCheckInputTestCase.interval
+		logInfoFile := verifyConsistencyCheckInputTestCase.logInfoFile
+		outputIdentitiesFile := verifyConsistencyCheckInputTestCase.outputIdentitiesFile
+		once := verifyConsistencyCheckInputTestCase.once
+		expectedError := verifyConsistencyCheckInputTestCase.expectedError
+		err := VerifyConsistencyCheckInputs(interval, logInfoFile, outputIdentitiesFile, once)
+		if (err == nil && expectedError != nil) || (err != nil && expectedError != nil && err.Error() != expectedError.Error()) {
+			t.Errorf("%s: expected error %v, received error %v", verifyConsistencyCheckInputTestCaseName, expectedError, err)
+		}
 	}
 }

--- a/pkg/test/e2e/e2e_test.go
+++ b/pkg/test/e2e/e2e_test.go
@@ -170,7 +170,7 @@ func TestRunConsistencyCheck(t *testing.T) {
 	}
 	once := true
 
-	err = rekor.RunConsistencyCheck(&interval, rekorClient, verifier, &tempLogInfoFileName, monitoredVals, &tempOutputIdentitiesFileName, &once)
+	err = rekor.RunConsistencyCheck(interval, rekorClient, verifier, tempLogInfoFileName, monitoredVals, tempOutputIdentitiesFileName, once)
 	if err != nil {
 		t.Errorf("first consistency check failed: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestRunConsistencyCheck(t *testing.T) {
 		t.Errorf("expected checkpoint size of 2, received size %d", checkpoint.Size)
 	}
 
-	err = rekor.RunConsistencyCheck(&interval, rekorClient, verifier, &tempLogInfoFileName, monitoredVals, &tempOutputIdentitiesFileName, &once)
+	err = rekor.RunConsistencyCheck(interval, rekorClient, verifier, tempLogInfoFileName, monitoredVals, tempOutputIdentitiesFileName, once)
 	if err != nil {
 		t.Errorf("second consistency check failed: %v", err)
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As part of the refactoring work outlined [in this doc](https://docs.google.com/document/d/15XEwkUDy2Wp9oSpazD18vMMbeo-UDpqpzPAiiMkGvFk/edit?resourcekey=0-l0iCV7L2HCa8xC3XCEz8rg&tab=t.0#heading=h.xgjl2srtytjt), this PR refactors the RunConsistencyCheck workflow to take in string/boolean values directly from parsed flag inputs instead of pointers. In doing so, this PR adds a function to check that CLI flags are set correctly and verifies as such in the reusable monitoring workflow. 

This PR depends on #483; [this is the relevant commit](https://github.com/sigstore/rekor-monitor/pull/489/commits/38115b4c3f8dfb35d6257eb1bc0f76d67a9e96a0) introducing the workflow input changes from pointer to static variable inputs.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
