### PR TITLE
Add reading identity metadata file functionality

### DIFF
--- a/pkg/util/file/file_test.go
+++ b/pkg/util/file/file_test.go
@@ -155,7 +155,7 @@ func TestReadWriteCTSignedTreeHead(t *testing.T) {
 	}
 }
 
-func TestWriteIdentityMetadata(t *testing.T) {
+func TestReadWriteIdentityMetadata(t *testing.T) {
 	tempDir := t.TempDir()
 	tempMetadataFile, err := os.CreateTemp(tempDir, "")
 	if err != nil {
@@ -168,12 +168,11 @@ func TestWriteIdentityMetadata(t *testing.T) {
 		LatestIndex: 1,
 	})
 
-	tempMetadata, err := os.ReadFile(tempMetadataFileName)
+	idMetadata, err := ReadIdentityMetadata(tempMetadataFileName)
 	if err != nil {
-		t.Errorf("error reading from output identities file: %v", err)
+		t.Errorf("failed to read identity metadata: %v", err)
 	}
-	tempMetadataString := string(tempMetadata)
-	if !strings.Contains(tempMetadataString, "1") {
-		t.Errorf("expected to find index 1, did not in %s", tempMetadataString)
+	if idMetadata == nil || idMetadata.LatestIndex != 1 {
+		t.Errorf("expected latest index of 1, received incorrect or nil")
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR adds functionality to read from an identity metadata file, which currently only consists of the last searched index in a log checkpoint, but can be expanded to include more metadata as becomes relevant. It also modifies current testing to test read/write functionality of the identity metadata file.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
