### PR TITLE
Refactor matching on Object Identifiers

### DIFF
--- a/pkg/fulcio/extensions/extensions.go
+++ b/pkg/fulcio/extensions/extensions.go
@@ -192,7 +192,7 @@ type OIDMatchers struct {
 	CustomExtensions []CustomExtension
 }
 
-func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDExtension, error) {
+func (e FulcioExtensions) RenderFulcioOIDMatchers() []OIDExtension {
 	var exts []OIDExtension
 
 	// BEGIN: Deprecated
@@ -329,15 +329,12 @@ func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDExtension, error) {
 		})
 	}
 
-	return exts, nil
+	return exts
 }
 
-// RenderOIDMatchers groups all OID matchers from OIDMatchers, FulcioExtensions, and CustomOIDs into one slice of OIDMatchers
+// RenderOIDMatchers groups all OID matchers from OIDExtensions, FulcioExtensions, and CustomExtensions into one slice of OIDMatchers
 func (oidMatchers OIDMatchers) RenderOIDMatchers() ([]OIDExtension, error) {
-	fulcioOIDMatchers, err := oidMatchers.FulcioExtensions.RenderFulcioOIDMatchers()
-	if err != nil {
-		return nil, fmt.Errorf("error rendering OID matchers from Fulcio OID extensions: %w", err)
-	}
+	fulcioOIDMatchers := oidMatchers.FulcioExtensions.RenderFulcioOIDMatchers()
 	// map of all OID extensions to all associated matching extension values
 	oidMap := make(map[string]map[string]bool)
 	// dedup OID extensions and associated values through one mapping

--- a/pkg/fulcio/extensions/extensions.go
+++ b/pkg/fulcio/extensions/extensions.go
@@ -173,56 +173,63 @@ type FulcioExtensions struct {
 	SourceRepositoryVisibilityAtSigning []string `json:"SourceRepositoryVisibilityAtSigning,omitempty" yaml:"source-repository-visibility-at-signing,omitempty"` // 1.3.6.1.4.1.57264.1.22
 }
 
-// OIDMatcher holds an OID field and a list of values to match on
-type OIDMatcher struct {
+// OIDExtension holds an OID field and a list of values to match on
+type OIDExtension struct {
 	ObjectIdentifier asn1.ObjectIdentifier `yaml:"objectIdentifier"`
 	ExtensionValues  []string              `yaml:"extensionValues"`
 }
 
-// CustomOID holds an OID field represented in dot notation and a list of values to match on
+// CustomExtension holds an OID field represented in dot notation and a list of values to match on
 type CustomExtension struct {
 	ObjectIdentifier string   `yaml:"objectIdentifier"`
 	ExtensionValues  []string `yaml:"extensionValues"`
 }
 
-func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDMatcher, error) {
-	var exts []OIDMatcher
+// OIDMatchers holds all FulcioExtensions, OIDMatchers, and CustomExtensions
+type OIDMatchers struct {
+	OIDExtensions    []OIDExtension
+	FulcioExtensions FulcioExtensions
+	CustomExtensions []CustomExtension
+}
+
+func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDExtension, error) {
+	var exts []OIDExtension
 
 	// BEGIN: Deprecated
 	if len(e.Issuer) != 0 {
 		// deprecated issuer extension due to incorrect encoding
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDIssuer,
 			ExtensionValues:  e.Issuer,
 		})
 	}
 
 	if len(e.GithubWorkflowTrigger) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDGitHubWorkflowTrigger,
 			ExtensionValues:  e.GithubWorkflowTrigger,
 		})
 	}
 	if len(e.GithubWorkflowSHA) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDGitHubWorkflowSHA,
 			ExtensionValues:  e.GithubWorkflowSHA,
 		})
 	}
 	if len(e.GithubWorkflowName) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDGitHubWorkflowName,
 			ExtensionValues:  e.GithubWorkflowName,
 		})
 	}
 	if len(e.GithubWorkflowRepository) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDGitHubWorkflowRepository,
 			ExtensionValues:  e.GithubWorkflowRepository,
 		})
 	}
 	if len(e.GithubWorkflowRef) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDGitHubWorkflowRef,
 			ExtensionValues:  e.GithubWorkflowRef,
 		})
@@ -231,92 +238,92 @@ func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDMatcher, error) {
 
 	// duplicate issuer with correct RFC 5280 encoding
 	if len(e.Issuer) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDIssuerV2,
 			ExtensionValues:  e.Issuer,
 		})
 	}
 
 	if len(e.BuildSignerURI) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDBuildSignerURI,
 			ExtensionValues:  e.BuildSignerURI,
 		})
 	}
 	if len(e.BuildSignerDigest) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDBuildSignerDigest,
 			ExtensionValues:  e.BuildSignerDigest,
 		})
 	}
 	if len(e.RunnerEnvironment) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDRunnerEnvironment,
 			ExtensionValues:  e.RunnerEnvironment,
 		})
 	}
 	if len(e.SourceRepositoryURI) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryURI,
 			ExtensionValues:  e.SourceRepositoryURI,
 		})
 	}
 	if len(e.SourceRepositoryDigest) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryDigest,
 			ExtensionValues:  e.SourceRepositoryDigest,
 		})
 	}
 	if len(e.SourceRepositoryRef) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryRef,
 			ExtensionValues:  e.SourceRepositoryRef,
 		})
 	}
 	if len(e.SourceRepositoryIdentifier) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryIdentifier,
 			ExtensionValues:  e.SourceRepositoryIdentifier,
 		})
 	}
 	if len(e.SourceRepositoryOwnerURI) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryOwnerURI,
 			ExtensionValues:  e.SourceRepositoryOwnerURI,
 		})
 	}
 	if len(e.SourceRepositoryOwnerIdentifier) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryOwnerIdentifier,
 			ExtensionValues:  e.SourceRepositoryOwnerIdentifier,
 		})
 	}
 	if len(e.BuildConfigURI) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDBuildConfigURI,
 			ExtensionValues:  e.BuildConfigURI,
 		})
 	}
 	if len(e.BuildConfigDigest) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDBuildConfigDigest,
 			ExtensionValues:  e.BuildConfigDigest,
 		})
 	}
 	if len(e.BuildTrigger) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDBuildTrigger,
 			ExtensionValues:  e.BuildTrigger,
 		})
 	}
 	if len(e.RunInvocationURI) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDRunInvocationURI,
 			ExtensionValues:  e.RunInvocationURI,
 		})
 	}
 	if len(e.SourceRepositoryVisibilityAtSigning) != 0 {
-		exts = append(exts, OIDMatcher{
+		exts = append(exts, OIDExtension{
 			ObjectIdentifier: OIDSourceRepositoryVisibilityAtSigning,
 			ExtensionValues:  e.SourceRepositoryVisibilityAtSigning,
 		})
@@ -325,16 +332,16 @@ func (e FulcioExtensions) RenderFulcioOIDMatchers() ([]OIDMatcher, error) {
 	return exts, nil
 }
 
-// MergeOIDMatchers groups all OID matchers from OIDMatchers, FulcioExtensions, and CustomOIDs into one slice of OIDMatchers
-func MergeOIDMatchers(oidMatchers []OIDMatcher, fulcioExtensions FulcioExtensions, customExtensions []CustomExtension) ([]OIDMatcher, error) {
-	fulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
+// RenderOIDMatchers groups all OID matchers from OIDMatchers, FulcioExtensions, and CustomOIDs into one slice of OIDMatchers
+func (oidMatchers OIDMatchers) RenderOIDMatchers() ([]OIDExtension, error) {
+	fulcioOIDMatchers, err := oidMatchers.FulcioExtensions.RenderFulcioOIDMatchers()
 	if err != nil {
 		return nil, fmt.Errorf("error rendering OID matchers from Fulcio OID extensions: %w", err)
 	}
 	// map of all OID extensions to all associated matching extension values
 	oidMap := make(map[string]map[string]bool)
 	// dedup OID extensions and associated values through one mapping
-	for _, oidMatcher := range oidMatchers {
+	for _, oidMatcher := range oidMatchers.OIDExtensions {
 		oidMatcherString := oidMatcher.ObjectIdentifier.String()
 		oidMap[oidMatcherString] = make(map[string]bool)
 		for _, extValue := range oidMatcher.ExtensionValues {
@@ -348,7 +355,7 @@ func MergeOIDMatchers(oidMatchers []OIDMatcher, fulcioExtensions FulcioExtension
 			oidMap[oidMatcherString][extValue] = true
 		}
 	}
-	for _, customOID := range customExtensions {
+	for _, customOID := range oidMatchers.CustomExtensions {
 		customOIDString := customOID.ObjectIdentifier
 		oidMap[customOIDString] = make(map[string]bool)
 		for _, extValue := range customOID.ExtensionValues {
@@ -357,7 +364,7 @@ func MergeOIDMatchers(oidMatchers []OIDMatcher, fulcioExtensions FulcioExtension
 	}
 
 	// convert map into list of OIDMatchers
-	var allMatchers []OIDMatcher
+	var allMatchers []OIDExtension
 	for oidExtension, extValueMap := range oidMap {
 		parsedOID, err := ParseObjectIdentifier(oidExtension)
 		if err != nil {
@@ -367,7 +374,7 @@ func MergeOIDMatchers(oidMatchers []OIDMatcher, fulcioExtensions FulcioExtension
 		for extValue := range extValueMap {
 			extValues = append(extValues, extValue)
 		}
-		allMatchers = append(allMatchers, OIDMatcher{
+		allMatchers = append(allMatchers, OIDExtension{
 			ObjectIdentifier: parsedOID,
 			ExtensionValues:  extValues,
 		})

--- a/pkg/fulcio/extensions/extensions_test.go
+++ b/pkg/fulcio/extensions/extensions_test.go
@@ -20,72 +20,73 @@ import (
 	"testing"
 )
 
-// Test mergeOIDMatchers
-func TestMergeOIDMatchers(t *testing.T) {
-	oidMatchers, err := MergeOIDMatchers([]OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{},
-	}}, FulcioExtensions{}, []CustomExtension{})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
+// Test RenderOIDMatchers
+func TestRenderOIDMatchers(t *testing.T) {
+	testCases := map[string]struct {
+		inputOIDMatchers OIDMatchers
+		expectedLen      int
+	}{
+		"one OIDExtension": {
+			inputOIDMatchers: OIDMatchers{
+				OIDExtensions: []OIDExtension{{
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+					ExtensionValues:  []string{},
+				}},
+			},
+			expectedLen: 1,
+		},
+		"one OIDExtension with extValues": {
+			inputOIDMatchers: OIDMatchers{
+				OIDExtensions: []OIDExtension{{
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+					ExtensionValues:  []string{"test", "test2"},
+				}},
+			},
+			expectedLen: 1,
+		},
+		"two OIDExtensions with same OID field": {
+			inputOIDMatchers: OIDMatchers{
+				OIDExtensions: []OIDExtension{{
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+					ExtensionValues:  []string{"test1"},
+				}, {
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+					ExtensionValues:  []string{"test"},
+				}},
+			},
+			expectedLen: 1,
+		},
+		"all OID extension types supported": {
+			inputOIDMatchers: OIDMatchers{
+				OIDExtensions: []OIDExtension{{
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
+					ExtensionValues:  []string{"test1"},
+				}, {
+					ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 18},
+					ExtensionValues:  []string{"test"},
+				}},
+				FulcioExtensions: FulcioExtensions{
+					BuildConfigDigest: []string{"test"},
+				},
+				CustomExtensions: []CustomExtension{{
+					ObjectIdentifier: "2.5.29.16",
+					ExtensionValues:  []string{"test"},
+				}},
+			},
+			expectedLen: 4,
+		},
 	}
 
-	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{""},
-	}}, FulcioExtensions{}, []CustomExtension{})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test", "test2"},
-	}}, FulcioExtensions{}, []CustomExtension{})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test1"},
-	}, {
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test"},
-	}}, FulcioExtensions{}, []CustomExtension{})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 1 {
-		t.Errorf("Expected 1 OIDMatcher, got %d", len(oidMatchers))
-	}
-
-	oidMatchers, err = MergeOIDMatchers([]OIDMatcher{{
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
-		ExtensionValues:  []string{"test1"},
-	}, {
-		ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 18},
-		ExtensionValues:  []string{"test"},
-	}}, FulcioExtensions{
-		BuildConfigDigest: []string{"test"},
-	}, []CustomExtension{{
-		ObjectIdentifier: "2.5.29.16",
-		ExtensionValues:  []string{"test"},
-	}})
-	if err != nil {
-		t.Errorf("Expected nil, got %v", err)
-	}
-	if len(oidMatchers) != 4 {
-		t.Errorf("Expected 4 OIDMatchers, got %d", len(oidMatchers))
+	for _, tc := range testCases {
+		oidMatchers, err := tc.inputOIDMatchers.RenderOIDMatchers()
+		if err != nil {
+			t.Errorf("expected nil, received %v", err)
+		}
+		expectedLen := tc.expectedLen
+		resultLen := len(oidMatchers)
+		if expectedLen != resultLen {
+			t.Errorf("expected %d OID matchers, received %d", expectedLen, resultLen)
+		}
 	}
 }
 
@@ -168,7 +169,7 @@ func TestRenderFulcioOIDMatchers(t *testing.T) {
 	buildSignerURIMatcherOID := buildSignerURIMatcher.ObjectIdentifier
 	buildSignerURIMatcherExtValues := buildSignerURIMatcher.ExtensionValues
 	if !buildSignerURIMatcherOID.Equal(OIDBuildSignerURI) {
-		t.Errorf("expected OIDMatcher to be BuildSignerURI 1.3.6.1.4.1.57264.1.9, received %s", buildSignerURIMatcherOID)
+		t.Errorf("expected OIDExtension to be BuildSignerURI 1.3.6.1.4.1.57264.1.9, received %s", buildSignerURIMatcherOID)
 	}
 	if len(buildSignerURIMatcherExtValues) != 1 {
 		t.Errorf("expected BuildSignerURI extension values to have length 1, received %d", len(buildSignerURIMatcherExtValues))
@@ -182,7 +183,7 @@ func TestRenderFulcioOIDMatchers(t *testing.T) {
 	buildConfigURIMatcherOID := buildConfigURIMatcher.ObjectIdentifier
 	buildConfigURIMatcherExtValues := buildConfigURIMatcher.ExtensionValues
 	if !buildConfigURIMatcherOID.Equal(OIDBuildConfigURI) {
-		t.Errorf("expected OIDMatcher to be BuildConfigURI 1.3.6.1.4.1.57264.1.18, received %s", buildConfigURIMatcherOID)
+		t.Errorf("expected OIDExtension to be BuildConfigURI 1.3.6.1.4.1.57264.1.18, received %s", buildConfigURIMatcherOID)
 	}
 
 	if len(buildConfigURIMatcherExtValues) != 6 {

--- a/pkg/fulcio/extensions/extensions_test.go
+++ b/pkg/fulcio/extensions/extensions_test.go
@@ -156,10 +156,7 @@ func TestRenderFulcioOIDMatchers(t *testing.T) {
 		BuildConfigURI: []string{"1", "2", "3", "4", "5", "6"},
 	}
 
-	renderedFulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
-	if err != nil {
-		t.Errorf("expected nil, received error %v", err)
-	}
+	renderedFulcioOIDMatchers := fulcioExtensions.RenderFulcioOIDMatchers()
 
 	if len(renderedFulcioOIDMatchers) != 2 {
 		t.Errorf("expected OIDMatchers to have length 2, received length %d", len(renderedFulcioOIDMatchers))
@@ -216,10 +213,7 @@ func TestRenderFulcioOIDMatchersAllFields(t *testing.T) {
 		RunInvocationURI:                    []string{testValueString},
 	}
 
-	renderedFulcioOIDMatchers, err := fulcioExtensions.RenderFulcioOIDMatchers()
-	if err != nil {
-		t.Errorf("expected nil, received error %v", err)
-	}
+	renderedFulcioOIDMatchers := fulcioExtensions.RenderFulcioOIDMatchers()
 
 	if len(renderedFulcioOIDMatchers) != 21 {
 		t.Errorf("expected OIDMatchers to have length 21, received length %d", len(renderedFulcioOIDMatchers))

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -44,18 +44,9 @@ type MonitoredValues struct {
 	// Subjects contains a list of subjects that are not specified in a
 	// certificate, such as a SSH key or PGP key email address
 	Subjects []string `yaml:"subjects"`
-	// OIDMatchers contains a list of OID extension fields and associated values
-	// ex. Build Signer URI, associated with specific workflow URIs
-	OIDExtensions []extensions.OIDExtension `yaml:"oidMatchers"`
-	// FulcioExtensions contains all extensions currently supported by Fulcio
-	// each extension has a list of values to match on, ex. `build-signer-uri`
-	FulcioExtensions extensions.FulcioExtensions `yaml:"fulcioExtensions"`
-	// CustomExtensions contains a list of custom extension fields, represented in dot notation
-	// and associated values to match on.
-	CustomExtensions []extensions.CustomExtension `yaml:"customExtensions"`
 	// OIDMatchers represents a list of OID extension fields and associated values,
 	// which includes those constructed directly, those supported by Fulcio, and any constructed via dot notation.
-	OIDMatchers extensions.OIDMatchers
+	OIDMatchers []extensions.OIDExtension `yaml:"oidMatchers"`
 }
 
 // LogEntry holds a certificate subject, issuer, OID extension and associated value, and log entry metadata
@@ -109,7 +100,7 @@ func CreateIdentitiesList(mvs MonitoredValues) []string {
 	identities = append(identities, mvs.Fingerprints...)
 	identities = append(identities, mvs.Subjects...)
 
-	for _, oidMatcher := range mvs.OIDExtensions {
+	for _, oidMatcher := range mvs.OIDMatchers {
 		identities = append(identities, oidMatcher.ExtensionValues...)
 	}
 
@@ -182,7 +173,7 @@ func MonitoredValuesExist(mvs MonitoredValues) bool {
 	if len(mvs.Fingerprints) > 0 {
 		return true
 	}
-	if len(mvs.OIDExtensions) > 0 {
+	if len(mvs.OIDMatchers) > 0 {
 		return true
 	}
 	if len(mvs.Subjects) > 0 {

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -46,13 +46,16 @@ type MonitoredValues struct {
 	Subjects []string `yaml:"subjects"`
 	// OIDMatchers contains a list of OID extension fields and associated values
 	// ex. Build Signer URI, associated with specific workflow URIs
-	OIDMatchers []extensions.OIDMatcher `yaml:"oidMatchers"`
+	OIDExtensions []extensions.OIDExtension `yaml:"oidMatchers"`
 	// FulcioExtensions contains all extensions currently supported by Fulcio
 	// each extension has a list of values to match on, ex. `build-signer-uri`
 	FulcioExtensions extensions.FulcioExtensions `yaml:"fulcioExtensions"`
 	// CustomExtensions contains a list of custom extension fields, represented in dot notation
 	// and associated values to match on.
 	CustomExtensions []extensions.CustomExtension `yaml:"customExtensions"`
+	// OIDMatchers represents a list of OID extension fields and associated values,
+	// which includes those constructed directly, those supported by Fulcio, and any constructed via dot notation.
+	OIDMatchers extensions.OIDMatchers
 }
 
 // LogEntry holds a certificate subject, issuer, OID extension and associated value, and log entry metadata
@@ -106,7 +109,7 @@ func CreateIdentitiesList(mvs MonitoredValues) []string {
 	identities = append(identities, mvs.Fingerprints...)
 	identities = append(identities, mvs.Subjects...)
 
-	for _, oidMatcher := range mvs.OIDMatchers {
+	for _, oidMatcher := range mvs.OIDExtensions {
 		identities = append(identities, oidMatcher.ExtensionValues...)
 	}
 
@@ -179,7 +182,7 @@ func MonitoredValuesExist(mvs MonitoredValues) bool {
 	if len(mvs.Fingerprints) > 0 {
 		return true
 	}
-	if len(mvs.OIDMatchers) > 0 {
+	if len(mvs.OIDExtensions) > 0 {
 		return true
 	}
 	if len(mvs.Subjects) > 0 {

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -255,7 +255,7 @@ func TestMonitoredValuesExist(t *testing.T) {
 		},
 		"oid matchers": {
 			mvs: MonitoredValues{
-				OIDMatchers: []extensions.OIDMatcher{
+				OIDMatchers: []extensions.OIDExtension{
 					{
 						ObjectIdentifier: asn1.ObjectIdentifier{1},
 						ExtensionValues:  []string{"test extension value"},

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -293,7 +293,7 @@ func TestCreateIdentitiesList(t *testing.T) {
 				},
 				Fingerprints: []string{"example-fingerprint"},
 				Subjects:     []string{"example-subject"},
-				OIDMatchers: []extensions.OIDMatcher{
+				OIDMatchers: []extensions.OIDExtension{
 					{
 						ObjectIdentifier: asn1.ObjectIdentifier{1, 4, 1, 9},
 						ExtensionValues:  []string{"example-oid-matcher"},

--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -57,12 +57,6 @@ var (
 
 // MatchedIndices returns a list of log indices that contain the requested identities.
 func MatchedIndices(logEntries []models.LogEntry, mvs identity.MonitoredValues) ([]identity.LogEntry, error) {
-	allOIDMatchers, err := mvs.OIDMatchers.RenderOIDMatchers()
-	if err != nil {
-		return nil, err
-	}
-	// TODO: OIDMatchers should be preprocessed and merged before being passed into MatchedIndices
-	mvs.OIDMatchers = allOIDMatchers
 	if err := verifyMonitoredValues(mvs); err != nil {
 		return nil, err
 	}

--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -26,7 +26,6 @@ import (
 	"regexp"
 
 	"github.com/go-openapi/runtime"
-	"github.com/sigstore/rekor-monitor/pkg/fulcio/extensions"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/util/file"
 	"github.com/sigstore/rekor/pkg/generated/client"
@@ -58,7 +57,7 @@ var (
 
 // MatchedIndices returns a list of log indices that contain the requested identities.
 func MatchedIndices(logEntries []models.LogEntry, mvs identity.MonitoredValues) ([]identity.LogEntry, error) {
-	allOIDMatchers, err := extensions.MergeOIDMatchers(mvs.OIDMatchers, mvs.FulcioExtensions, mvs.CustomExtensions)
+	allOIDMatchers, err := mvs.OIDMatchers.RenderOIDMatchers()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rekor/identity_test.go
+++ b/pkg/rekor/identity_test.go
@@ -526,7 +526,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 
 	// match to oid with matching extension value
 	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		OIDMatchers: []extensions.OIDMatcher{
+		OIDMatchers: []extensions.OIDExtension{
 			{
 				ObjectIdentifier: oid,
 				ExtensionValues:  []string{extValueString},
@@ -547,7 +547,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 
 	testedMonitoredValues := []identity.MonitoredValues{
 		{
-			OIDMatchers: []extensions.OIDMatcher{
+			OIDMatchers: []extensions.OIDExtension{
 				{
 					ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
 					ExtensionValues:  []string{"wrong"},
@@ -555,7 +555,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 			},
 		},
 		{
-			OIDMatchers: []extensions.OIDMatcher{
+			OIDMatchers: []extensions.OIDExtension{
 				{
 					ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 14},
 					ExtensionValues:  []string{"test cert value"},
@@ -651,7 +651,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 
 	// no match to oid with different extension value
 	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
-		OIDMatchers: []extensions.OIDMatcher{
+		OIDMatchers: []extensions.OIDExtension{
 			{
 				ObjectIdentifier: asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 9},
 				ExtensionValues:  []string{"wrong"},
@@ -821,28 +821,28 @@ func TestMatchedIndicesFailures(t *testing.T) {
 			errorString: "fingerprint empty",
 		},
 		"empty oid extension": {
-			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDExtension{{
 				ObjectIdentifier: asn1.ObjectIdentifier{},
 				ExtensionValues:  []string{""},
 			}}},
 			errorString: "could not parse object identifier: empty input",
 		},
 		"empty oid matched values": {
-			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDExtension{{
 				ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 				ExtensionValues:  []string{},
 			}}},
 			errorString: "oid matched values empty",
 		},
 		"empty oid matched value": {
-			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDExtension{{
 				ObjectIdentifier: asn1.ObjectIdentifier{2, 5, 29, 17},
 				ExtensionValues:  []string{""},
 			}}},
 			errorString: "oid matched value empty",
 		},
 		"empty oid field": {
-			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDMatcher{{
+			input: identity.MonitoredValues{OIDMatchers: []extensions.OIDExtension{{
 				ObjectIdentifier: asn1.ObjectIdentifier{},
 				ExtensionValues:  []string{""},
 			}}},

--- a/pkg/test/e2e/e2e_test.go
+++ b/pkg/test/e2e/e2e_test.go
@@ -155,7 +155,7 @@ func TestRunConsistencyCheck(t *testing.T) {
 				Issuers:     []string{".+@domain.com"},
 			},
 		},
-		OIDMatchers: []extensions.OIDMatcher{
+		OIDMatchers: []extensions.OIDExtension{
 			{
 				ObjectIdentifier: oid,
 				ExtensionValues:  []string{extValueString},

--- a/pkg/test/identity_workflow/identity_workflow_e2e_test.go
+++ b/pkg/test/identity_workflow/identity_workflow_e2e_test.go
@@ -157,7 +157,7 @@ func TestIdentitySearch(t *testing.T) {
 				Issuers:     []string{".+@domain.com"},
 			},
 		},
-		OIDMatchers: []extensions.OIDMatcher{
+		OIDMatchers: []extensions.OIDExtension{
 			{
 				ObjectIdentifier: oid,
 				ExtensionValues:  []string{extValueString},


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Per issue #520, this PR refactors matching for ObjectIdentifiers: A separate struct is created for users to pass in inputs for OID extensions and associated values, via direct construction of asn1.ObjectIdentifiers, from OID extensions currently supported by Fulcio, or via dot notation. These OID extensions are then parsed and rendered before being passed into MatchedIndices so that it is easier to keep track of all OID matchers in one list, rather than in separate structs. This PR also prepares for refactoring of MatchedIndices into separate helpers.

Fixes #520 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE- workflows are run the same

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
