### PR TITLE
Add support for Fulcio to rekor-monitor identity workflow

### DIFF
--- a/pkg/ct/identity.go
+++ b/pkg/ct/identity.go
@@ -1,0 +1,67 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file copies some of the functionality in pkg/identity/identity.go
+// related to retrieving OID extension values and matching on them,
+// but refactors them to use the Google-specific fork of encoding/asn1 and crypto/x509.
+
+package ct
+
+import (
+	"encoding/asn1"
+	"fmt"
+
+	google_asn1 "github.com/google/certificate-transparency-go/asn1"
+	google_x509 "github.com/google/certificate-transparency-go/x509"
+)
+
+// getExtension gets a certificate extension by OID where the extension value is an
+// ASN.1-encoded string
+func getExtension(cert *google_x509.Certificate, oid google_asn1.ObjectIdentifier) (string, error) {
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(oid) {
+			continue
+		}
+		var extValue string
+		rest, err := asn1.Unmarshal(ext.Value, &extValue)
+		if err != nil {
+			return "", fmt.Errorf("%w", err)
+		}
+		if len(rest) != 0 {
+			return "", fmt.Errorf("unmarshalling extension had rest for oid %v", oid)
+		}
+		return extValue, nil
+	}
+	return "", nil
+}
+
+// OIDMatchesPolicy returns if a certificate contains both a given OID field and a matching value associated with that field
+// if true, it returns the OID extension and extension value that were matched on
+func OIDMatchesPolicy(cert *google_x509.Certificate, oid google_asn1.ObjectIdentifier, extensionValues []string) (bool, google_asn1.ObjectIdentifier, string, error) {
+	extValue, err := getExtension(cert, oid)
+	if err != nil {
+		return false, nil, "", fmt.Errorf("error getting extension value: %w", err)
+	}
+	if extValue == "" {
+		return false, nil, "", nil
+	}
+
+	for _, extensionValue := range extensionValues {
+		if extValue == extensionValue {
+			return true, oid, extValue, nil
+		}
+	}
+
+	return false, nil, "", nil
+}

--- a/pkg/ct/identity_test.go
+++ b/pkg/ct/identity_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ct
+
+import (
+	"testing"
+
+	google_asn1 "github.com/google/certificate-transparency-go/asn1"
+	"github.com/google/certificate-transparency-go/x509"
+)
+
+// Test when OID is not present in the certificate
+func TestOIDNotPresent(t *testing.T) {
+	cert := &x509.Certificate{} // No extensions
+	oid := google_asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"wrong value"}
+
+	matches, _, _, err := OIDMatchesPolicy(cert, oid, extensionValues)
+	if matches || err != nil {
+		t.Errorf("Expected false with nil, got %v, error %v", matches, err)
+	}
+}
+
+// Test when OID is present and matches value
+func TestOIDMatchesValue(t *testing.T) {
+	cert, err := mockCertificateWithExtension(google_asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	oid := google_asn1.ObjectIdentifier{2, 5, 29, 17}
+	extValueString := "test cert value"
+	extensionValues := []string{extValueString}
+
+	matches, matchedOID, extValue, err := OIDMatchesPolicy(cert, oid, extensionValues)
+	if !matches || err != nil {
+		t.Errorf("Expected true, got %v, error %v", matches, err)
+	}
+	if matchedOID.String() != oid.String() {
+		t.Errorf("Expected oid to equal 2.5.29.17, got %s", matchedOID.String())
+	}
+	if extValue != extValueString {
+		t.Errorf("Expected string to equal 'test cert value', got %s", extValue)
+	}
+}

--- a/pkg/ct/monitor_test.go
+++ b/pkg/ct/monitor_test.go
@@ -15,12 +15,16 @@
 package ct
 
 import (
+	"encoding/asn1"
 	"reflect"
 	"testing"
+
+	google_asn1 "github.com/google/certificate-transparency-go/asn1"
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509/pkix"
+	"github.com/sigstore/rekor-monitor/pkg/fulcio/extensions"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 )
 
@@ -29,7 +33,7 @@ const (
 	organizationName = "test-org"
 )
 
-func TestScanEntrySubject(t *testing.T) {
+func TestScanEntryCertSubject(t *testing.T) {
 	testCases := map[string]struct {
 		inputEntry    ct.LogEntry
 		inputSubjects []string
@@ -68,9 +72,74 @@ func TestScanEntrySubject(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		logEntries, err := ScanEntrySubject(tc.inputEntry, tc.inputSubjects)
+		logEntries, err := ScanEntryCertSubject(tc.inputEntry, tc.inputSubjects)
 		if err != nil {
 			t.Errorf("received error scanning entry for subjects: %v", err)
+		}
+		expected := tc.expected
+		if logEntries == nil {
+			if expected != nil {
+				t.Errorf("received nil, expected log entry")
+			}
+		} else {
+			if !reflect.DeepEqual(logEntries, expected) {
+				t.Errorf("expected %v, received %v", expected, logEntries)
+			}
+		}
+	}
+}
+
+func TestScanEntryOIDExtensions(t *testing.T) {
+	cert, err := mockCertificateWithExtension(google_asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	unmatchedAsn1OID := asn1.ObjectIdentifier{2}
+	matchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extValueString := "test cert value"
+	testCases := map[string]struct {
+		inputEntry         ct.LogEntry
+		inputOIDExtensions []extensions.OIDExtension
+		expected           []*identity.LogEntry
+	}{
+		"no matching subject": {
+			inputEntry: ct.LogEntry{
+				Index:    1,
+				X509Cert: cert,
+			},
+			inputOIDExtensions: []extensions.OIDExtension{
+				{
+					ObjectIdentifier: unmatchedAsn1OID,
+					ExtensionValues:  []string{extValueString},
+				},
+			},
+			expected: []*identity.LogEntry{},
+		},
+		"matching subject": {
+			inputEntry: ct.LogEntry{
+				Index:    1,
+				X509Cert: cert,
+			},
+			inputOIDExtensions: []extensions.OIDExtension{
+				{
+					ObjectIdentifier: matchedAsn1OID,
+					ExtensionValues:  []string{extValueString},
+				},
+			},
+			expected: []*identity.LogEntry{
+				{
+					Index:          1,
+					OIDExtension:   matchedAsn1OID,
+					ExtensionValue: extValueString,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		logEntries, err := ScanEntryOIDExtensions(tc.inputEntry, tc.inputOIDExtensions)
+		if err != nil {
+			t.Errorf("received error scanning entry for oid extensions: %v", err)
 		}
 		expected := tc.expected
 		if logEntries == nil {

--- a/pkg/ct/monitor_test.go
+++ b/pkg/ct/monitor_test.go
@@ -16,7 +16,6 @@ package ct
 
 import (
 	"encoding/asn1"
-	"reflect"
 	"testing"
 
 	google_asn1 "github.com/google/certificate-transparency-go/asn1"
@@ -82,8 +81,19 @@ func TestScanEntryCertSubject(t *testing.T) {
 				t.Errorf("received nil, expected log entry")
 			}
 		} else {
-			if !reflect.DeepEqual(logEntries, expected) {
-				t.Errorf("expected %v, received %v", expected, logEntries)
+			for i, resultEntry := range logEntries {
+				expectedEntry := tc.expected[i]
+				resultIndex := resultEntry.Index
+				expectedIndex := expectedEntry.Index
+				if resultIndex != expectedIndex {
+					t.Errorf("expected index %d, received index %d", expectedIndex, resultIndex)
+				}
+
+				resultCertSubject := resultEntry.CertSubject
+				expectedCertSubject := expectedEntry.CertSubject
+				if resultCertSubject != expectedCertSubject {
+					t.Errorf("expected cert subject %s, received cert subject %s", expectedCertSubject, resultCertSubject)
+				}
 			}
 		}
 	}
@@ -147,8 +157,25 @@ func TestScanEntryOIDExtensions(t *testing.T) {
 				t.Errorf("received nil, expected log entry")
 			}
 		} else {
-			if !reflect.DeepEqual(logEntries, expected) {
-				t.Errorf("expected %v, received %v", expected, logEntries)
+			for i, resultEntry := range logEntries {
+				expectedEntry := tc.expected[i]
+				resultIndex := resultEntry.Index
+				expectedIndex := expectedEntry.Index
+				if resultIndex != expectedIndex {
+					t.Errorf("expected index %d, received index %d", expectedIndex, resultIndex)
+				}
+
+				resultOID := resultEntry.OIDExtension.String()
+				expectedOID := expectedEntry.OIDExtension.String()
+				if resultOID != expectedOID {
+					t.Errorf("expected oid %s, received oid %s", expectedOID, resultOID)
+				}
+
+				resultExtValue := resultEntry.ExtensionValue
+				expectedExtValue := expectedEntry.ExtensionValue
+				if resultExtValue != expectedExtValue {
+					t.Errorf("expected extension value %s, received extension value %s", expectedExtValue, resultExtValue)
+				}
 			}
 		}
 	}

--- a/pkg/ct/test_utils.go
+++ b/pkg/ct/test_utils.go
@@ -19,6 +19,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	google_asn1 "github.com/google/certificate-transparency-go/asn1"
+	"github.com/google/certificate-transparency-go/x509"
+	google_pkix "github.com/google/certificate-transparency-go/x509/pkix"
 )
 
 const (
@@ -50,4 +54,21 @@ func serveRspAt(t *testing.T, path, rsp string) *httptest.Server {
 			t.Fatal(err)
 		}
 	})
+}
+
+func mockCertificateWithExtension(oid google_asn1.ObjectIdentifier, value string) (*x509.Certificate, error) {
+	extValue, err := google_asn1.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	cert := &x509.Certificate{
+		Extensions: []google_pkix.Extension{
+			{
+				Id:       oid,
+				Critical: false,
+				Value:    extValue,
+			},
+		},
+	}
+	return cert, nil
 }

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -15,12 +15,21 @@
 package identity
 
 import (
+	"crypto/x509"
 	"encoding/asn1"
 	"encoding/json"
+	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/sigstore/rekor-monitor/pkg/fulcio/extensions"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+)
+
+var (
+	certExtensionOIDCIssuer   = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}
+	certExtensionOIDCIssuerV2 = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 8}
 )
 
 // CertificateIdentity holds a certificate subject and an optional list of identity issuers
@@ -180,4 +189,99 @@ func MonitoredValuesExist(mvs MonitoredValues) bool {
 		return true
 	}
 	return false
+}
+
+// getExtension gets a certificate extension by OID where the extension value is an
+// ASN.1-encoded string
+func getExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) (string, error) {
+	for _, ext := range cert.Extensions {
+		if !ext.Id.Equal(oid) {
+			continue
+		}
+		var extValue string
+		rest, err := asn1.Unmarshal(ext.Value, &extValue)
+		if err != nil {
+			return "", fmt.Errorf("%w", err)
+		}
+		if len(rest) != 0 {
+			return "", fmt.Errorf("unmarshalling extension had rest for oid %v", oid)
+		}
+		return extValue, nil
+	}
+	return "", nil
+}
+
+// getDeprecatedExtension gets a certificate extension by OID where the extension value is a raw string
+func getDeprecatedExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) (string, error) {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(oid) {
+			return string(ext.Value), nil
+		}
+	}
+	return "", nil
+}
+
+// OIDMatchesPolicy returns if a certificate contains both a given OID field and a matching value associated with that field
+// if true, it returns the OID extension and extension value that were matched on
+func OIDMatchesPolicy(cert *x509.Certificate, oid asn1.ObjectIdentifier, extensionValues []string) (bool, asn1.ObjectIdentifier, string, error) {
+	extValue, err := getExtension(cert, oid)
+	if err != nil {
+		return false, nil, "", fmt.Errorf("error getting extension value: %w", err)
+	}
+	if extValue == "" {
+		return false, nil, "", nil
+	}
+
+	for _, extensionValue := range extensionValues {
+		if extValue == extensionValue {
+			return true, oid, extValue, nil
+		}
+	}
+
+	return false, nil, "", nil
+}
+
+// CertMatchesPolicy returns true if a certificate contains a given subject and optionally a given issuer
+// expectedSub and expectedIssuers can be regular expressions
+// CertMatchesPolicy also returns the matched subject and issuer on success
+func CertMatchesPolicy(cert *x509.Certificate, expectedSub string, expectedIssuers []string) (bool, string, string, error) {
+	sans := cryptoutils.GetSubjectAlternateNames(cert)
+	var issuer string
+	var err error
+	issuer, err = getExtension(cert, certExtensionOIDCIssuerV2)
+	if err != nil || issuer == "" {
+		// fallback to deprecated issuer extension
+		issuer, err = getDeprecatedExtension(cert, certExtensionOIDCIssuer)
+		if err != nil || issuer == "" {
+			return false, "", "", err
+		}
+	}
+	subjectMatches := false
+	regex, err := regexp.Compile(expectedSub)
+	if err != nil {
+		return false, "", "", fmt.Errorf("malformed subject regex: %w", err)
+	}
+	matchedSub := ""
+	for _, sub := range sans {
+		if regex.MatchString(sub) {
+			subjectMatches = true
+			matchedSub = sub
+		}
+	}
+	// allow any issuer
+	if len(expectedIssuers) == 0 {
+		return subjectMatches, matchedSub, issuer, nil
+	}
+
+	issuerMatches := false
+	for _, expectedIss := range expectedIssuers {
+		regex, err := regexp.Compile(expectedIss)
+		if err != nil {
+			return false, "", "", fmt.Errorf("malformed issuer regex: %w", err)
+		}
+		if regex.MatchString(issuer) {
+			issuerMatches = true
+		}
+	}
+	return subjectMatches && issuerMatches, matchedSub, issuer, nil
 }

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -15,6 +15,8 @@
 package identity
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"reflect"
 	"sort"
@@ -311,5 +313,105 @@ func TestCreateIdentitiesList(t *testing.T) {
 		if !reflect.DeepEqual(result, expected) {
 			t.Errorf("expected %v, received %v", expected, result)
 		}
+	}
+}
+
+func mockCertificateWithExtension(oid asn1.ObjectIdentifier, value string) (*x509.Certificate, error) {
+	extValue, err := asn1.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	cert := &x509.Certificate{
+		Extensions: []pkix.Extension{
+			{
+				Id:       oid,
+				Critical: false,
+				Value:    extValue,
+			},
+		},
+	}
+	return cert, nil
+}
+
+// Test when OID is present but the value does not match
+func TestOIDDoesNotMatch(t *testing.T) {
+	cert, err := mockCertificateWithExtension(asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"wrong value"}
+
+	matches, _, _, err := OIDMatchesPolicy(cert, oid, extensionValues)
+	if matches || err != nil {
+		t.Errorf("Expected false without error, got %v, error %v", matches, err)
+	}
+}
+
+// Test when OID is not present in the certificate
+func TestOIDNotPresent(t *testing.T) {
+	cert := &x509.Certificate{} // No extensions
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extensionValues := []string{"wrong value"}
+
+	matches, _, _, err := OIDMatchesPolicy(cert, oid, extensionValues)
+	if matches || err != nil {
+		t.Errorf("Expected false with nil, got %v, error %v", matches, err)
+	}
+}
+
+// Test when OID is present and matches value
+func TestOIDMatchesValue(t *testing.T) {
+	cert, err := mockCertificateWithExtension(asn1.ObjectIdentifier{2, 5, 29, 17}, "test cert value")
+	if err != nil {
+		t.Errorf("Expected nil got %v", err)
+	}
+	oid := asn1.ObjectIdentifier{2, 5, 29, 17}
+	extValueString := "test cert value"
+	extensionValues := []string{extValueString}
+
+	matches, matchedOID, extValue, err := OIDMatchesPolicy(cert, oid, extensionValues)
+	if !matches || err != nil {
+		t.Errorf("Expected true, got %v, error %v", matches, err)
+	}
+	if matchedOID.String() != oid.String() {
+		t.Errorf("Expected oid to equal 2.5.29.17, got %s", matchedOID.String())
+	}
+	if extValue != extValueString {
+		t.Errorf("Expected string to equal 'test cert value', got %s", extValue)
+	}
+}
+
+// Test when cert is present but the value does not match
+func TestCertDoesNotMatch(t *testing.T) {
+	emailAddr := "test@address.com"
+	cert := &x509.Certificate{
+		EmailAddresses: []string{emailAddr},
+	}
+	matches, _, _, err := CertMatchesPolicy(cert, "", []string{})
+	if matches || err != nil {
+		t.Errorf("Expected false without error, got %v, error %v", matches, err)
+	}
+}
+
+// Test when cert is present but the value does not match
+func TestCertMatches(t *testing.T) {
+	emailAddr := "test@address.com"
+	issuer := "test-issuer"
+	cert := &x509.Certificate{
+		EmailAddresses: []string{emailAddr},
+		Extensions: []pkix.Extension{
+			{
+				Id:    certExtensionOIDCIssuer,
+				Value: []byte(issuer),
+			},
+		},
+	}
+	matches, receivedSub, receivedIssuer, err := CertMatchesPolicy(cert, emailAddr, []string{issuer})
+	if !matches || err != nil {
+		t.Errorf("Expected true without error, got %v, error %v", matches, err)
+	}
+	if receivedSub != emailAddr || receivedIssuer != issuer {
+		t.Errorf("expected subject %s and issuer %s, received subject %s and issuer %s", emailAddr, issuer, receivedSub, receivedIssuer)
 	}
 }

--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/x509"
-	"encoding/asn1"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -34,7 +33,6 @@ import (
 	"github.com/sigstore/rekor/pkg/pki"
 	"github.com/sigstore/rekor/pkg/types"
 	"github.com/sigstore/rekor/pkg/util"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
 
 	// required imports to call init methods
 	_ "github.com/sigstore/rekor/pkg/types/alpine/v0.0.1"
@@ -49,11 +47,6 @@ import (
 	_ "github.com/sigstore/rekor/pkg/types/rfc3161/v0.0.1"
 	_ "github.com/sigstore/rekor/pkg/types/rpm/v0.0.1"
 	_ "github.com/sigstore/rekor/pkg/types/tuf/v0.0.1"
-)
-
-var (
-	certExtensionOIDCIssuer   = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}
-	certExtensionOIDCIssuerV2 = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 8}
 )
 
 func MatchLogEntryFingerprints(logEntryAnon models.LogEntryAnon, uuid string, entryFingerprints []string, monitoredFingerprints []string) []identity.LogEntry {
@@ -76,7 +69,7 @@ func MatchLogEntryCertificateIdentities(logEntryAnon models.LogEntryAnon, uuid s
 	matchedEntries := []identity.LogEntry{}
 	for _, monitoredCertID := range monitoredCertIDs {
 		for _, cert := range entryCertificates {
-			match, sub, iss, err := certMatchesPolicy(cert, monitoredCertID.CertSubject, monitoredCertID.Issuers)
+			match, sub, iss, err := identity.CertMatchesPolicy(cert, monitoredCertID.CertSubject, monitoredCertID.Issuers)
 			if err != nil {
 				return nil, fmt.Errorf("error with policy matching for UUID %s at index %d: %w", uuid, logEntryAnon.LogIndex, err)
 			} else if match {
@@ -116,7 +109,7 @@ func MatchLogEntryOIDs(logEntryAnon models.LogEntryAnon, uuid string, entryCerti
 	matchedEntries := []identity.LogEntry{}
 	for _, monitoredOID := range monitoredOIDMatchers {
 		for _, cert := range entryCertificates {
-			match, oid, extValue, err := oidMatchesPolicy(cert, monitoredOID.ObjectIdentifier, monitoredOID.ExtensionValues)
+			match, oid, extValue, err := identity.OIDMatchesPolicy(cert, monitoredOID.ObjectIdentifier, monitoredOID.ExtensionValues)
 			if err != nil {
 				return nil, fmt.Errorf("error with policy matching for UUID %s at index %d: %w", uuid, logEntryAnon.LogIndex, err)
 			}
@@ -275,101 +268,6 @@ func extractAllIdentities(verifiers []pki.PublicKey) ([]string, []*x509.Certific
 		}
 	}
 	return subjects, certificates, fps, nil
-}
-
-// getExtension gets a certificate extension by OID where the extension value is an
-// ASN.1-encoded string
-func getExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) (string, error) {
-	for _, ext := range cert.Extensions {
-		if !ext.Id.Equal(oid) {
-			continue
-		}
-		var extValue string
-		rest, err := asn1.Unmarshal(ext.Value, &extValue)
-		if err != nil {
-			return "", fmt.Errorf("%w", err)
-		}
-		if len(rest) != 0 {
-			return "", fmt.Errorf("unmarshalling extension had rest for oid %v", oid)
-		}
-		return extValue, nil
-	}
-	return "", nil
-}
-
-// getDeprecatedExtension gets a certificate extension by OID where the extension value is a raw string
-func getDeprecatedExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) (string, error) {
-	for _, ext := range cert.Extensions {
-		if ext.Id.Equal(oid) {
-			return string(ext.Value), nil
-		}
-	}
-	return "", nil
-}
-
-// certMatchesPolicy returns true if a certificate contains a given subject and optionally a given issuer
-// expectedSub and expectedIssuers can be regular expressions
-// certMatchesPolicy also returns the matched subject and issuer on success
-func certMatchesPolicy(cert *x509.Certificate, expectedSub string, expectedIssuers []string) (bool, string, string, error) {
-	sans := cryptoutils.GetSubjectAlternateNames(cert)
-	var issuer string
-	var err error
-	issuer, err = getExtension(cert, certExtensionOIDCIssuerV2)
-	if err != nil || issuer == "" {
-		// fallback to deprecated issuer extension
-		issuer, err = getDeprecatedExtension(cert, certExtensionOIDCIssuer)
-		if err != nil || issuer == "" {
-			return false, "", "", err
-		}
-	}
-	subjectMatches := false
-	regex, err := regexp.Compile(expectedSub)
-	if err != nil {
-		return false, "", "", fmt.Errorf("malformed subject regex: %w", err)
-	}
-	matchedSub := ""
-	for _, sub := range sans {
-		if regex.MatchString(sub) {
-			subjectMatches = true
-			matchedSub = sub
-		}
-	}
-	// allow any issuer
-	if len(expectedIssuers) == 0 {
-		return subjectMatches, matchedSub, issuer, nil
-	}
-
-	issuerMatches := false
-	for _, expectedIss := range expectedIssuers {
-		regex, err := regexp.Compile(expectedIss)
-		if err != nil {
-			return false, "", "", fmt.Errorf("malformed issuer regex: %w", err)
-		}
-		if regex.MatchString(issuer) {
-			issuerMatches = true
-		}
-	}
-	return subjectMatches && issuerMatches, matchedSub, issuer, nil
-}
-
-// oidMatchesPolicy returns if a certificate contains both a given OID field and a matching value associated with that field
-// if true, it returns the OID extension and extension value that were matched on
-func oidMatchesPolicy(cert *x509.Certificate, oid asn1.ObjectIdentifier, extensionValues []string) (bool, asn1.ObjectIdentifier, string, error) {
-	extValue, err := getExtension(cert, oid)
-	if err != nil {
-		return false, nil, "", fmt.Errorf("error getting extension value: %w", err)
-	}
-	if extValue == "" {
-		return false, nil, "", nil
-	}
-
-	for _, extensionValue := range extensionValues {
-		if extValue == extensionValue {
-			return true, oid, extValue, nil
-		}
-	}
-
-	return false, nil, "", nil
 }
 
 func GetPrevCurrentCheckpoints(client *client.Rekor, logInfoFile string) (*util.SignedCheckpoint, *util.SignedCheckpoint, error) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Per [this doc](https://docs.google.com/document/d/1fdO5jMTJOtMhIWs_lzWlb25olIWMvYix8LW7ugeMH8k/edit?tab=t.0#heading=h.xgjl2srtytjt), this PR refactors the identity monitor portion of rekor-monitor to support monitoring a Fulcio CT log instance for any monitored identities, notifying via any of various notification platforms.

This PR depends on #526 and #527.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Rekor-monitor is now capable of monitoring certificate transparency log instances

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

#TODO: Update readme
