### PR TITLE
Refactor rekor-monitor workflow functionality

### DIFF
--- a/.github/workflows/reusable_monitoring.yml
+++ b/.github/workflows/reusable_monitoring.yml
@@ -81,7 +81,7 @@ jobs:
         run: cat ${{ env.LOG_FILE }}
         # Skip on first run
         continue-on-error: true
-      - run: go run ./cmd/rekor_monitor --file ${{ env.LOG_FILE }} --once=${{ inputs.once }} --user-agent "${{ format('{0}/{1}/{2}', needs.detect-workflow.outputs.repository, needs.detect-workflow.outputs.ref, github.run_id) }} --config ${{ inputs.config }}"
+      - run: go run ./cmd/rekor_monitor --file ${{ env.LOG_FILE }} --once=${{ inputs.once }} --user-agent "${{ format('{0}/{1}/{2}', needs.detect-workflow.outputs.repository, needs.detect-workflow.outputs.ref, github.run_id) }}" --config "${{ inputs.config }}"
       - name: Upload checkpoint
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -125,15 +125,7 @@ func main() {
 		inputEndIndex := config.EndIndex
 
 		var logInfo *models.LogInfo
-		if config.StartIndex == nil || config.EndIndex == nil {
-			logInfo, err = rekor.GetLogInfo(context.Background(), rekorClient)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error getting log info: %v", err)
-				return
-			}
-		}
-
-		err = rekor.RunConsistencyCheck(rekorClient, verifier, *logInfoFile)
+		logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, *logInfoFile)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
 			return

--- a/pkg/rekor/verifier_test.go
+++ b/pkg/rekor/verifier_test.go
@@ -19,9 +19,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/sigstore/rekor-monitor/pkg/rekor/mock"
 	"github.com/sigstore/rekor/pkg/generated/client"
@@ -47,59 +45,5 @@ func TestGetLogVerifier(t *testing.T) {
 	pubkey, _ := verifier.PublicKey()
 	if err := cryptoutils.EqualKeys(key.Public(), pubkey); err != nil {
 		t.Fatalf("expected equal keys: %v", err)
-	}
-}
-
-func TestVerifyConsistencyCheckInputs(t *testing.T) {
-	interval := 5 * time.Minute
-	logInfoFile := "./test/example_log_info_file_path.txt"
-	once := true
-	verifyConsistencyCheckInputTests := map[string]struct {
-		interval      *time.Duration
-		logInfoFile   *string
-		once          *bool
-		expectedError error
-	}{
-		"successful verification": {
-			interval:      &interval,
-			logInfoFile:   &logInfoFile,
-			once:          &once,
-			expectedError: nil,
-		},
-		"fail --interval verification": {
-			interval:      nil,
-			logInfoFile:   &logInfoFile,
-			once:          &once,
-			expectedError: errors.New("--interval flag equal to nil"),
-		},
-		"fail --file verification": {
-			interval:      &interval,
-			logInfoFile:   nil,
-			once:          &once,
-			expectedError: errors.New("--file flag equal to nil"),
-		},
-		"fail --once verification": {
-			interval:      &interval,
-			logInfoFile:   &logInfoFile,
-			once:          nil,
-			expectedError: errors.New("--once flag equal to nil"),
-		},
-		"empty case": {
-			interval:      nil,
-			logInfoFile:   nil,
-			once:          nil,
-			expectedError: errors.New("--interval flag equal to nil"),
-		},
-	}
-
-	for verifyConsistencyCheckInputTestCaseName, verifyConsistencyCheckInputTestCase := range verifyConsistencyCheckInputTests {
-		interval := verifyConsistencyCheckInputTestCase.interval
-		logInfoFile := verifyConsistencyCheckInputTestCase.logInfoFile
-		once := verifyConsistencyCheckInputTestCase.once
-		expectedError := verifyConsistencyCheckInputTestCase.expectedError
-		err := VerifyConsistencyCheckInputs(interval, logInfoFile, once)
-		if (err == nil && expectedError != nil) || (err != nil && expectedError != nil && err.Error() != expectedError.Error()) {
-			t.Errorf("%s: expected error %v, received error %v", verifyConsistencyCheckInputTestCaseName, expectedError, err)
-		}
 	}
 }

--- a/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
+++ b/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
@@ -178,9 +178,12 @@ func TestIdentitySearch(t *testing.T) {
 		t.Errorf("error getting log verifier: %v", err)
 	}
 
-	err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
+	logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
 	if err != nil {
 		t.Errorf("first consistency check failed: %v", err)
+	}
+	if logInfo == nil {
+		t.Errorf("first consistency check did not return log info")
 	}
 
 	configRenderedOIDMatchers, err := configMonitoredValues.OIDMatchers.RenderOIDMatchers()
@@ -218,9 +221,9 @@ func TestIdentitySearch(t *testing.T) {
 		t.Errorf("error creating log entry: %v", err)
 	}
 
-	logInfo, err = rekor.GetLogInfo(context.Background(), rekorClient)
+	logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
 	if err != nil {
-		t.Errorf("error getting log info: %v", err)
+		t.Errorf("second consistency check failed: %v", err)
 	}
 	checkpoint = &util.SignedCheckpoint{}
 	if err := checkpoint.UnmarshalText([]byte(*logInfo.SignedTreeHead)); err != nil {
@@ -228,11 +231,6 @@ func TestIdentitySearch(t *testing.T) {
 	}
 	if checkpoint.Size != 2 {
 		t.Errorf("expected checkpoint size of 2, received size %d", checkpoint.Size)
-	}
-
-	err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
-	if err != nil {
-		t.Errorf("second consistency check failed: %v", err)
 	}
 
 	_, err = rekor.IdentitySearch(0, 1, rekorClient, monitoredVals, tempOutputIdentitiesFileName, nil)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR refactors the rekor-monitor reusable workflow functionality by:
- Removing unnecessary VerifyConsistencyCheckInput function (all inputs will always have a default value set)
- Adding a models.LogInfo return value to RunConsistencyCheck (removes extraneous earlier GetLogInfo call)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
