### PR TITLE
Refactor RunConsistencyCheck to return previous checkpoint 

### DIFF
--- a/pkg/rekor/identity.go
+++ b/pkg/rekor/identity.go
@@ -283,7 +283,6 @@ func GetCheckpointIndex(logInfo *models.LogInfo, checkpoint *util.SignedCheckpoi
 }
 
 func IdentitySearch(startIndex int, endIndex int, rekorClient *client.Rekor, monitoredValues identity.MonitoredValues, outputIdentitiesFile string, idMetadataFile *string) ([]identity.MonitoredIdentity, error) {
-
 	entries, err := GetEntriesByIndexRange(context.Background(), rekorClient, startIndex, endIndex)
 	if err != nil {
 		return nil, fmt.Errorf("error getting entries by index range: %v", err)

--- a/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
+++ b/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
@@ -178,12 +178,15 @@ func TestIdentitySearch(t *testing.T) {
 		t.Errorf("error getting log verifier: %v", err)
 	}
 
-	logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
+	prevCheckpoint, logInfo, err := rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
 	if err != nil {
 		t.Errorf("first consistency check failed: %v", err)
 	}
 	if logInfo == nil {
 		t.Errorf("first consistency check did not return log info")
+	}
+	if prevCheckpoint != nil {
+		t.Errorf("first consistency check should not have returned checkpoint")
 	}
 
 	configRenderedOIDMatchers, err := configMonitoredValues.OIDMatchers.RenderOIDMatchers()
@@ -221,7 +224,7 @@ func TestIdentitySearch(t *testing.T) {
 		t.Errorf("error creating log entry: %v", err)
 	}
 
-	logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
+	prevCheckpoint, logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, tempLogInfoFileName)
 	if err != nil {
 		t.Errorf("second consistency check failed: %v", err)
 	}
@@ -231,6 +234,9 @@ func TestIdentitySearch(t *testing.T) {
 	}
 	if checkpoint.Size != 2 {
 		t.Errorf("expected checkpoint size of 2, received size %d", checkpoint.Size)
+	}
+	if prevCheckpoint.Size != 1 {
+		t.Errorf("expected previous checkpoint size of 1, received size %d", prevCheckpoint.Size)
 	}
 
 	_, err = rekor.IdentitySearch(0, 1, rekorClient, monitoredVals, tempOutputIdentitiesFileName, nil)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR refactors the RunConsistencyCheck() function to return the previously signed checkpoint for use in the IdentitySearch() function; this ensures that the identity monitor completes and fixes an error where the identity monitor attempted to run using the same checkpoint twice, resulting in an identical start and end index.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A
