### PR TITLE
Added timeout for GH Actions

### DIFF
--- a/.github/workflows/ct_reusable_monitoring.yml
+++ b/.github/workflows/ct_reusable_monitoring.yml
@@ -42,6 +42,7 @@ jobs:
     outputs:
       repository: ${{ steps.detect.outputs.repository }}
       ref: ${{ steps.detect.outputs.ref }}
+    timeout-minutes: 60
     steps:
       - name: Detect the repository and ref
         id: detect
@@ -54,6 +55,7 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     needs: [detect-workflow]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/reusable_monitoring.yml
+++ b/.github/workflows/reusable_monitoring.yml
@@ -46,6 +46,7 @@ env:
 jobs:
   detect-workflow:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       id-token: write # Needed to detect the current reusable repository and ref.
     outputs:
@@ -63,6 +64,7 @@ jobs:
   monitor:
     runs-on: ubuntu-latest
     needs: [detect-workflow]
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -94,6 +96,7 @@ jobs:
   if-succeeded:
     runs-on: ubuntu-latest
     needs: [monitor, detect-workflow]
+    timeout-minutes: 60
     permissions:
       issues: 'write'
     env:
@@ -112,6 +115,7 @@ jobs:
   if-failed:
     runs-on: ubuntu-latest
     needs: [monitor, detect-workflow]
+    timeout-minutes: 60
     permissions:
       issues: 'write'
     env:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Added timeout for GH Actions , fixes:  https://github.com/sigstore/rekor-monitor/issues/198

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
