### PR TITLE
Immediately tick to avoid waiting an interval

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -110,62 +110,64 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
-	// To get an immediate first tick
+	// To get an immediate first tick, for-select is at the end of the loop
 	for {
+		inputEndIndex := config.EndIndex
+
+		// TODO: Handle Rekor sharding
+		// https://github.com/sigstore/rekor-monitor/issues/57
+		var prevSTH *ctgo.SignedTreeHead
+		prevSTH, currentSTH, err := ct.RunConsistencyCheck(fulcioClient, *logInfoFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to successfully complete consistency check: %v", err)
+			return
+		}
+
+		if config.StartIndex == nil {
+			if prevSTH != nil {
+				checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
+				config.StartIndex = &checkpointStartIndex
+			} else {
+				defaultStartIndex := 0
+				config.StartIndex = &defaultStartIndex
+			}
+		}
+
+		if config.EndIndex == nil {
+			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
+			config.EndIndex = &checkpointEndIndex
+		}
+
+		if *config.StartIndex >= *config.EndIndex {
+			fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
+		}
+
+		if identity.MonitoredValuesExist(monitoredValues) {
+			foundEntries, err := ct.IdentitySearch(fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
+				return
+			}
+
+			notificationPool := notifications.CreateNotificationPool(config)
+
+			err = notifications.TriggerNotifications(notificationPool, foundEntries)
+			if err != nil {
+				// continue running consistency check if notifications fail to trigger
+				fmt.Fprintf(os.Stderr, "failed to trigger notifications: %v", err)
+			}
+		}
+
+		if *once || inputEndIndex != nil {
+			return
+		}
+
+		config.StartIndex = config.EndIndex
+		config.EndIndex = nil
+
 		select {
 		case <-ticker.C:
-			inputEndIndex := config.EndIndex
-
-			// TODO: Handle Rekor sharding
-			// https://github.com/sigstore/rekor-monitor/issues/57
-			var prevSTH *ctgo.SignedTreeHead
-			prevSTH, currentSTH, err := ct.RunConsistencyCheck(fulcioClient, *logInfoFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to successfully complete consistency check: %v", err)
-				return
-			}
-
-			if config.StartIndex == nil {
-				if prevSTH != nil {
-					checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
-					config.StartIndex = &checkpointStartIndex
-				} else {
-					defaultStartIndex := 0
-					config.StartIndex = &defaultStartIndex
-				}
-			}
-
-			if config.EndIndex == nil {
-				checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
-				config.EndIndex = &checkpointEndIndex
-			}
-
-			if *config.StartIndex >= *config.EndIndex {
-				fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
-			}
-
-			if identity.MonitoredValuesExist(monitoredValues) {
-				foundEntries, err := ct.IdentitySearch(fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
-					return
-				}
-
-				notificationPool := notifications.CreateNotificationPool(config)
-
-				err = notifications.TriggerNotifications(notificationPool, foundEntries)
-				if err != nil {
-					// continue running consistency check if notifications fail to trigger
-					fmt.Fprintf(os.Stderr, "failed to trigger notifications: %v", err)
-				}
-			}
-
-			if *once || inputEndIndex != nil {
-				return
-			}
-
-			config.StartIndex = config.EndIndex
-			config.EndIndex = nil
+			continue
 		case <-signalChan:
 			fmt.Fprintf(os.Stderr, "received signal, exiting")
 			return

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -123,63 +123,65 @@ func main() {
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
-	// To get an immediate first tick
+
+	// To get an immediate first tick, for-select is at the end of the loop
 	for {
+		inputEndIndex := config.EndIndex
+
+		// TODO: Handle Rekor sharding
+		// https://github.com/sigstore/rekor-monitor/issues/57
+		var logInfo *models.LogInfo
+		var prevCheckpoint *util.SignedCheckpoint
+		prevCheckpoint, logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, *logInfoFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
+			return
+		}
+
+		if config.StartIndex == nil {
+			if prevCheckpoint != nil {
+				checkpointStartIndex := rekor.GetCheckpointIndex(logInfo, prevCheckpoint)
+				config.StartIndex = &checkpointStartIndex
+			} else {
+				fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint")
+				return
+			}
+		}
+
+		if config.EndIndex == nil {
+			checkpoint, err := rekor.ReadLatestCheckpoint(logInfo)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error reading checkpoint: %v", err)
+				return
+			}
+
+			checkpointEndIndex := rekor.GetCheckpointIndex(logInfo, checkpoint)
+			config.EndIndex = &checkpointEndIndex
+		}
+
+		if *config.StartIndex >= *config.EndIndex {
+			fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
+			return
+		}
+
+		if identity.MonitoredValuesExist(monitoredValues) {
+			_, err = rekor.IdentitySearch(*config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
+				return
+			}
+		}
+
+		if *once || inputEndIndex != nil {
+			return
+		}
+
+		config.StartIndex = config.EndIndex
+		config.EndIndex = nil
+
 		select {
 		case <-ticker.C:
-			inputEndIndex := config.EndIndex
-
-			// TODO: Handle Rekor sharding
-			// https://github.com/sigstore/rekor-monitor/issues/57
-			var logInfo *models.LogInfo
-			var prevCheckpoint *util.SignedCheckpoint
-			prevCheckpoint, logInfo, err = rekor.RunConsistencyCheck(rekorClient, verifier, *logInfoFile)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
-				return
-			}
-
-			if config.StartIndex == nil {
-				if prevCheckpoint != nil {
-					checkpointStartIndex := rekor.GetCheckpointIndex(logInfo, prevCheckpoint)
-					config.StartIndex = &checkpointStartIndex
-				} else {
-					fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint")
-					return
-				}
-			}
-
-			if config.EndIndex == nil {
-				checkpoint, err := rekor.ReadLatestCheckpoint(logInfo)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "error reading checkpoint: %v", err)
-					return
-				}
-
-				checkpointEndIndex := rekor.GetCheckpointIndex(logInfo, checkpoint)
-				config.EndIndex = &checkpointEndIndex
-			}
-
-			if *config.StartIndex >= *config.EndIndex {
-				fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
-				return
-			}
-
-			if identity.MonitoredValuesExist(monitoredValues) {
-				_, err = rekor.IdentitySearch(*config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
-					return
-				}
-			}
-
-			if *once || inputEndIndex != nil {
-				return
-			}
-
-			config.StartIndex = config.EndIndex
-			config.EndIndex = nil
-
+			continue
 		case <-signalChan:
 			fmt.Fprintf(os.Stderr, "received signal, exiting")
 			return


### PR DESCRIPTION
Fixes https://github.com/sigstore/rekor-monitor/issues/588

With a recent refactor where we added support for catching a signal, this caused the ticker to wait a full interval before running the consistency check, which meant that runtime went from immediate to 5 min by default. This fixes the bug by moving the for-select logic to the end of the loop, a solution recommended online.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
