### PR TITLE
Update .golangci version to a supported one.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: "2.1"
 run:
   issues-exit-code: 1
 linters:


### PR DESCRIPTION
#### Summary
This is because #658 cannot merge as CI fails with

```
Error: Failed to run: Error: requested golangci-lint version 'v2.0' isn't supported: we support only v2.1.0 and later versions, Error: requested golangci-lint version 'v2.0' isn't supported: we support only v2.1.0 and later versions
    at getRequestedVersion (/home/runner/work/_actions/golangci/golangci-lint-action/4afd733a84b1f43292c63897423277bb7f4313a9/dist/run/index.js:93373:15)
    at getVersion (/home/runner/work/_actions/golangci/golangci-lint-action/4afd733a84b1f43292c63897423277bb7f4313a9/dist/run/index.js:93401:24)
    at install (/home/runner/work/_actions/golangci/golangci-lint-action/4afd733a84b1f43292c63897423277bb7f4313a9/dist/run/index.js:92623:56)
    at prepareEnv (/home/runner/work/_actions/golangci/golangci-lint-action/4afd733a84b1f43292c63897423277bb7f4313a9/dist/run/index.js:92938:49)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Error: requested golangci-lint version 'v2.0' isn't supported: we support only v2.1.0 and later versions
```

See logs at https://github.com/sigstore/rekor-monitor/actions/runs/14834872037/job/41643893372?pr=658
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
NONE

#### Documentation
NONE