### PR TITLE
fix: skip writing checkpoint when Rekor log is empty

### DIFF
--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -106,7 +106,7 @@ func ReadLatestCTSignedTreeHead(logInfoFile string) (*ct.SignedTreeHead, error) 
 
 // WriteCTSignedTreeHead writes a signed tree head to a given log file
 func WriteCTSignedTreeHead(sth *ct.SignedTreeHead, prev *ct.SignedTreeHead, logInfoFile string, force bool) error {
-	// Skip writing if the current checkpoint size is 0
+	// Skip writing if the current tree size is 0
 	if sth.TreeSize == 0 {
 		fmt.Fprintf(os.Stderr, "skipping write of tree head: tree size is 0\n")
 		return nil


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR proposes to fix a bug where rekor-monitor fails to proceed after a checkpoint is created when the Rekor log is empty. It detects the specific error about inability to compute consistency proofs from an empty log, deletes the stale checkpoint, and retries cleanly. This allows the monitor to recover automatically once entries are added to the Rekor log.

Issue: https://github.com/sigstore/rekor-monitor/issues/698

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
