### PR TITLE
ci: wrap inputs.config in ct_reusable_monitoring

### DIFF
--- a/.github/workflows/ct_reusable_monitoring.yml
+++ b/.github/workflows/ct_reusable_monitoring.yml
@@ -80,7 +80,7 @@ jobs:
         continue-on-error: true
       - run: |
           go run ./cmd/ct_monitor \
-          --config ${{ inputs.config }} \
+          --config "${{ inputs.config }}" \
           --file ${{ env.LOG_FILE }} \
           --once=${{ inputs.once }} \
           ${{ inputs.url && format('--url {0}', inputs.url) || '' }}


### PR DESCRIPTION
#### Summary
The yaml string should be wrapped in quotes so it is considered as a single argument for the `--config` flag, otherwise it is split in several arguments.

#### Release Note
* Fix `config` input use in ct_reusable_monitoring workflow