### PR TITLE
Deduplicate ct/rekor monitoring reusable workflows

### DIFF
--- a/.github/workflows/base_monitoring.yml
+++ b/.github/workflows/base_monitoring.yml
@@ -84,7 +84,7 @@ jobs:
         uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     # NOTE: This GHA should not be run concurrently.
     concurrency:
-      group: rekor-consistency-check
+      group: ${{ inputs.monitor_type }}-consistency-check
       cancel-in-progress: true
 
   monitor:
@@ -98,7 +98,8 @@ jobs:
           ref: "${{ needs.detect-workflow.outputs.ref }}"
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.23'
+          go-version-file: './go.mod'
+          check-latest: true
       - name: Download artifact
         uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
         with:

--- a/.github/workflows/base_monitoring.yml
+++ b/.github/workflows/base_monitoring.yml
@@ -1,0 +1,173 @@
+# Copyright 2025 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Base Monitoring Template
+
+on:
+  workflow_call:
+    inputs:
+      file_issue:
+        description: 'True to file an issue on monitoring failure'
+        required: false
+        default: false
+        type: boolean
+      artifact_retention_days:
+        description: 'The number of days to retain an artifact (default: 14). If this workflow runs as a cron job, it must be greater than the frequency of the job'
+        required: false
+        type: number
+        default: 14
+      once:
+        description: 'whether to run the identity monitor once or periodically'
+        default: true
+        required: false
+        type: boolean
+      config:
+        description: 'multiline yaml of configuration settings for identity monitor run'
+        required: false
+        type: string
+      url:
+        description: 'Optional URL to pass to the monitor'
+        required: false
+        type: string
+      uploaded_log_name:
+        description: 'Name of the uploaded log artifact'
+        required: false
+        type: string
+        default: checkpoint
+      checkpoint_file:
+        description: 'Name of the log info checkpoint file'
+        required: false
+        type: string
+        default: checkpoint_log.txt
+      monitor_type:
+        description: 'Type of monitor to run (rekor or ct)'
+        required: true
+        default: rekor
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  detect-workflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      id-token: write # Needed to detect the current reusable repository and ref.
+    outputs:
+      repository: ${{ steps.detect.outputs.repository }}
+      ref: ${{ steps.detect.outputs.ref }}
+    steps:
+      - name: Check monitor type
+        run: |
+          if [ "$INPUT_MONITOR_TYPE" != "rekor" ] && [ "$INPUT_MONITOR_TYPE" != "ct" ]; then
+            echo "Invalid monitor type: $INPUT_MONITOR_TYPE. Must be 'rekor' or 'ct'."
+            exit 1
+          fi
+        env:
+          INPUT_MONITOR_TYPE: ${{ inputs.monitor_type }}
+      - name: Detect the repository and ref
+        id: detect
+        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # NOTE: This GHA should not be run concurrently.
+    concurrency:
+      group: rekor-consistency-check
+      cancel-in-progress: true
+
+  monitor:
+    runs-on: ubuntu-latest
+    needs: [detect-workflow]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ needs.detect-workflow.outputs.repository }}
+          ref: "${{ needs.detect-workflow.outputs.ref }}"
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: '1.23'
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+        with:
+          name: ${{ inputs.uploaded_log_name }}
+        # Skip on first run since there will be no checkpoint
+        continue-on-error: true
+      - name: Log current checkpoints
+        run: cat ${{ inputs.checkpoint_file }}
+        # Skip on first run
+        continue-on-error: true
+      - if: ${{ inputs.monitor_type == 'rekor' }}
+        run: |
+          go run ./cmd/rekor_monitor \
+            --file ${{ inputs.checkpoint_file }} \
+            --once=${{ inputs.once }} \
+            --user-agent "${{ format('{0}/{1}/{2}', needs.detect-workflow.outputs.repository, needs.detect-workflow.outputs.ref, github.run_id) }}" \
+            --config "${{ inputs.config }}" \
+            ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
+      - if: ${{ inputs.monitor_type == 'ct' }}
+        run: |
+          go run ./cmd/ct_monitor \
+            --config "${{ inputs.config }}" \
+            --file ${{ inputs.checkpoint_file }} \
+            --once=${{ inputs.once }} \
+            ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
+      - name: Upload checkpoint
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ inputs.uploaded_log_name }}
+          path: ${{ inputs.checkpoint_file }}
+          retention-days: ${{ inputs.artifact_retention_days }}
+      - name: Log new checkpoints
+        run: cat ${{ inputs.checkpoint_file }}
+
+  if-succeeded:
+    runs-on: ubuntu-latest
+    needs: [monitor, detect-workflow]
+    timeout-minutes: 60
+    permissions:
+      issues: write
+      id-token: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_REPOSITORY: ${{ github.repository }}
+    if: ${{ needs.monitor.result == 'success' && inputs.file_issue }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ needs.detect-workflow.outputs.repository }}
+          ref: "${{ needs.detect-workflow.outputs.ref }}"
+      - run: |
+          set -euo pipefail
+          ./.github/workflows/scripts/report_success.sh
+
+  if-failed:
+    runs-on: ubuntu-latest
+    needs: [monitor, detect-workflow]
+    timeout-minutes: 60
+    permissions:
+      issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE_REPOSITORY: ${{ github.repository }}
+    if: ${{ always() && needs.monitor.result == 'failure' && inputs.file_issue }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: ${{ needs.detect-workflow.outputs.repository }}
+          ref: "${{ needs.detect-workflow.outputs.ref }}"
+      - run: |
+          set -euo pipefail
+          ./.github/workflows/scripts/report_failure.sh

--- a/.github/workflows/ct_reusable_monitoring.yml
+++ b/.github/workflows/ct_reusable_monitoring.yml
@@ -17,6 +17,15 @@ name: Certificate Transparency Monitoring Template
 on:
   workflow_call:
     inputs:
+      file_issue:
+        description: 'True to file an issue on monitoring failure'
+        required: true
+        type: boolean
+      artifact_retention_days:
+        description: 'The number of days to retain an artifact (default: 14). If this workflow runs as a cron job, it must be greater than the frequency of the job'
+        required: false
+        type: number
+        default: 14
       once:
         description: 'whether to run the identity monitor once or periodically'
         default: true
@@ -33,63 +42,18 @@ on:
 
 permissions:
   contents: read
-
-env:
-  UPLOADED_LOG_NAME: ct_checkpoint
-  LOG_FILE: ct_checkpoint_log.txt
+  id-token: write
+  issues: write
 
 jobs:
-  detect-workflow:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # Needed to detect the current reusable repository and ref.
-    outputs:
-      repository: ${{ steps.detect.outputs.repository }}
-      ref: ${{ steps.detect.outputs.ref }}
-    timeout-minutes: 60
-    steps:
-      - name: Detect the repository and ref
-        id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    # NOTE: This GHA should not be run concurrently.
-    concurrency:
-      group: certificate-transparency-monitor
-      cancel-in-progress: true
-
-  monitor:
-    runs-on: ubuntu-latest
-    needs: [detect-workflow]
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: '1.23'
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
-        with:
-          name: ${{ env.UPLOADED_LOG_NAME }}
-        # Skip on first run since there will be no checkpoint
-        continue-on-error: true
-      - name: Log current checkpoints
-        run: cat ${{ env.LOG_FILE }}
-        # Skip on first run
-        continue-on-error: true
-      - run: |
-          go run ./cmd/ct_monitor \
-          --config "${{ inputs.config }}" \
-          --file ${{ env.LOG_FILE }} \
-          --once=${{ inputs.once }} \
-          ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
-
-      - name: Upload checkpoint
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.UPLOADED_LOG_NAME }}
-          path: ${{ env.LOG_FILE }}
-          retention-days: ${{ inputs.artifact_retention_days }}
-      - name: Log new checkpoints
-        run: cat ${{ env.LOG_FILE }}
+  ct-monitoring:
+    uses: ./.github/workflows/base_monitoring.yml
+    with:
+      uploaded_log_name: ct_checkpoint
+      checkpoint_file: ct_checkpoint_log.txt
+      monitor_type: ct
+      file_issue: ${{ inputs.file_issue }}
+      artifact_retention_days: ${{ inputs.artifact_retention_days }}
+      once: ${{ inputs.once }}
+      config: ${{ inputs.config }}
+      url: ${{ inputs.url }}

--- a/.github/workflows/reusable_monitoring.yml
+++ b/.github/workflows/reusable_monitoring.yml
@@ -42,101 +42,18 @@ on:
 
 permissions:
   contents: read
-
-env:
-  UPLOADED_LOG_NAME: checkpoint
-  LOG_FILE: checkpoint_log.txt
+  id-token: write
+  issues: write
 
 jobs:
-  detect-workflow:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      id-token: write # Needed to detect the current reusable repository and ref.
-    outputs:
-      repository: ${{ steps.detect.outputs.repository }}
-      ref: ${{ steps.detect.outputs.ref }}
-    steps:
-      - name: Detect the repository and ref
-        id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
-    # NOTE: This GHA should not be run concurrently.
-    concurrency:
-      group: rekor-consistency-check
-      cancel-in-progress: true
-
-  monitor:
-    runs-on: ubuntu-latest
-    needs: [detect-workflow]
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version: '1.23'
-      - name: Download artifact
-        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
-        with:
-          name: ${{ env.UPLOADED_LOG_NAME }}
-        # Skip on first run since there will be no checkpoint
-        continue-on-error: true
-      - name: Log current checkpoints
-        run: cat ${{ env.LOG_FILE }}
-        # Skip on first run
-        continue-on-error: true
-      - run: |
-          go run ./cmd/rekor_monitor \
-            --file ${{ env.LOG_FILE }} \
-            --once=${{ inputs.once }} \
-            --user-agent "${{ format('{0}/{1}/{2}', needs.detect-workflow.outputs.repository, needs.detect-workflow.outputs.ref, github.run_id) }}" \
-            --config "${{ inputs.config }}" \
-            ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
-      - name: Upload checkpoint
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: ${{ env.UPLOADED_LOG_NAME }}
-          path: ${{ env.LOG_FILE }}
-          retention-days: ${{ inputs.artifact_retention_days }}
-      - name: Log new checkpoints
-        run: cat ${{ env.LOG_FILE }}
-
-  if-succeeded:
-    runs-on: ubuntu-latest
-    needs: [monitor, detect-workflow]
-    timeout-minutes: 60
-    permissions:
-      issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: ${{ github.repository }}
-    if: ${{ needs.monitor.result == 'success' && inputs.file_issue }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
-      - run: |
-          set -euo pipefail
-          ./.github/workflows/scripts/report_success.sh
-
-  if-failed:
-    runs-on: ubuntu-latest
-    needs: [monitor, detect-workflow]
-    timeout-minutes: 60
-    permissions:
-      issues: 'write'
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      ISSUE_REPOSITORY: ${{ github.repository }}
-    if: ${{ always() && needs.monitor.result == 'failure' && inputs.file_issue }}
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
-      - run: |
-          set -euo pipefail
-          ./.github/workflows/scripts/report_failure.sh
+  rekor-monitoring:
+    uses: ./.github/workflows/base_monitoring.yml
+    with:
+      uploaded_log_name: checkpoint
+      checkpoint_file: checkpoint_log.txt
+      monitor_type: rekor
+      file_issue: ${{ inputs.file_issue }}
+      artifact_retention_days: ${{ inputs.artifact_retention_days }}
+      once: ${{ inputs.once }}
+      config: ${{ inputs.config }}
+      url: ${{ inputs.url }}


### PR DESCRIPTION
#### Summary
Reduce duplicated workflow code between `ct_reusable_monitoring` and `reusable_monitoring` by moving the common code into `base_monitoring` workflow, called by both files with different parameters.

#### Release Note
* Add `file_issue` and `artifact_retention_days` parameters to `ct_reusable_workflow`, similar to `reusable_workflow`.