### PR TITLE
Deduplicate ct and rekor monitors

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,224 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sigstore/rekor-monitor/pkg/identity"
+	"github.com/sigstore/rekor-monitor/pkg/notifications"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/release-utils/version"
+)
+
+// MonitorFlags contains all the command-line flags for monitor applications
+type MonitorFlags struct {
+	ConfigFile    string
+	ConfigYaml    string
+	Once          bool
+	LogInfoFile   string
+	ServerURL     string
+	Interval      time.Duration
+	UserAgent     string
+	TUFRepository string
+}
+
+// LoopLogsParams contains the parameters for the LoopLogs function
+type LoopLogsParams struct {
+	Interval              time.Duration
+	Config                *notifications.IdentityMonitorConfiguration
+	MonitoredValues       identity.MonitoredValues
+	Once                  bool
+	RunConsistencyCheckFn func(ctx context.Context) (Checkpoint, Checkpoint, error)
+	GetStartIndexFn       func(prev, cur Checkpoint) *int
+	GetEndIndexFn         func(prev, cur Checkpoint) *int
+	IdentitySearchFn      func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error)
+}
+
+type Checkpoint interface{}
+
+// ParseMonitorFlags parses command-line flags and returns a MonitorFlags struct
+func ParseMonitorFlags(defaultServerURL, defaultTUFRepository string, baseUserAgentName string) *MonitorFlags {
+	configFilePath := flag.String("config-file", "", "path to yaml configuration file containing identity monitor settings")
+	configYamlInput := flag.String("config", "", "string with YAML configuration containing identity monitor settings")
+	once := flag.Bool("once", true, "whether to run the monitor on a repeated interval or once")
+	logInfoFile := flag.String("file", "", "path to the initial log info checkpoint file to be read from")
+	serverURL := flag.String("url", defaultServerURL, "URL to the server that is to be monitored")
+	interval := flag.Duration("interval", 5*time.Minute, "Length of interval between each periodical consistency check")
+	userAgentString := flag.String("user-agent", "", "details to include in the user agent string")
+	tufRepository := flag.String("tuf-repository", defaultTUFRepository, "TUF repository to use. Can be 'default' or 'staging'")
+	flag.Parse()
+
+	finalUserAgent := strings.TrimSpace(fmt.Sprintf("%s/%s (%s; %s) %s",
+		baseUserAgentName,
+		version.GetVersionInfo().GitVersion,
+		runtime.GOOS,
+		runtime.GOARCH,
+		*userAgentString,
+	))
+
+	return &MonitorFlags{
+		ConfigFile:    *configFilePath,
+		ConfigYaml:    *configYamlInput,
+		Once:          *once,
+		LogInfoFile:   *logInfoFile,
+		ServerURL:     *serverURL,
+		Interval:      *interval,
+		UserAgent:     finalUserAgent,
+		TUFRepository: *tufRepository,
+	}
+}
+
+// LoadMonitorConfig loads the monitor configuration from flags
+func LoadMonitorConfig(flags *MonitorFlags, defaultOutputFile string) (*notifications.IdentityMonitorConfiguration, error) {
+	var config notifications.IdentityMonitorConfiguration
+
+	if flags.ConfigFile != "" && flags.ConfigYaml != "" {
+		return nil, fmt.Errorf("error: only one of --config and --config-file should be specified")
+	}
+
+	if flags.ConfigFile != "" {
+		readConfig, err := os.ReadFile(flags.ConfigFile)
+		if err != nil {
+			return nil, fmt.Errorf("error reading from identity monitor configuration file: %v", err)
+		}
+
+		configString := string(readConfig)
+		if err := yaml.Unmarshal([]byte(configString), &config); err != nil {
+			return nil, fmt.Errorf("error parsing identities: %v", err)
+		}
+	}
+
+	if flags.ConfigYaml != "" {
+		if err := yaml.Unmarshal([]byte(flags.ConfigYaml), &config); err != nil {
+			return nil, fmt.Errorf("error parsing identities: %v", err)
+		}
+	}
+
+	if config.OutputIdentitiesFile == "" {
+		config.OutputIdentitiesFile = defaultOutputFile
+	}
+
+	return &config, nil
+}
+
+// ParseAndLoadConfig is a convenience function that parses flags and loads config
+func ParseAndLoadConfig(defaultServerURL, defaultTUFRepository, defaultOutputFile, baseUserAgentName string) (*MonitorFlags, *notifications.IdentityMonitorConfiguration, error) {
+	flags := ParseMonitorFlags(defaultServerURL, defaultTUFRepository, baseUserAgentName)
+	config, err := LoadMonitorConfig(flags, defaultOutputFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	return flags, config, nil
+}
+
+// PrintMonitoredValues prints the monitored values to the console
+func PrintMonitoredValues(monitoredValues identity.MonitoredValues) {
+	for _, certID := range monitoredValues.CertificateIdentities {
+		if len(certID.Issuers) == 0 {
+			fmt.Printf("Monitoring certificate subject %s\n", certID.CertSubject)
+		} else {
+			fmt.Printf("Monitoring certificate subject %s for issuer(s) %s\n", certID.CertSubject, strings.Join(certID.Issuers, ","))
+		}
+	}
+	for _, fp := range monitoredValues.Fingerprints {
+		fmt.Printf("Monitoring fingerprint %s\n", fp)
+	}
+	for _, sub := range monitoredValues.Subjects {
+		fmt.Printf("Monitoring subject %s\n", sub)
+	}
+}
+
+func LoopLogs(params LoopLogsParams) {
+	ticker := time.NewTicker(params.Interval)
+	defer ticker.Stop()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	config := params.Config
+
+	// To get an immediate first tick, for-select is at the end of the loop
+	for {
+		fmt.Fprint(os.Stderr, "New monitor run at ", time.Now().Format(time.RFC3339), "\n")
+		inputEndIndex := config.EndIndex
+
+		prevCheckpoint, curCheckpoint, err := params.RunConsistencyCheckFn(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
+			return
+		}
+
+		if identity.MonitoredValuesExist(params.MonitoredValues) {
+			if config.StartIndex == nil {
+				if prevCheckpoint != nil {
+					config.StartIndex = params.GetStartIndexFn(prevCheckpoint, curCheckpoint)
+				} else {
+					fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint")
+					return
+				}
+			}
+
+			if config.EndIndex == nil {
+				config.EndIndex = params.GetEndIndexFn(prevCheckpoint, curCheckpoint)
+			}
+
+			if *config.StartIndex >= *config.EndIndex {
+				fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
+				return
+			}
+
+			foundEntries, err := params.IdentitySearchFn(ctx, config, params.MonitoredValues)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
+				return
+			}
+
+			if len(foundEntries) > 0 {
+				notificationPool := notifications.CreateNotificationPool(*config)
+
+				err = notifications.TriggerNotifications(notificationPool, foundEntries)
+				if err != nil {
+					// continue running consistency check if notifications fail to trigger
+					fmt.Fprintf(os.Stderr, "failed to trigger notifications: %v", err)
+				}
+			}
+
+			config.StartIndex = config.EndIndex
+			config.EndIndex = nil
+		}
+
+		if params.Once || inputEndIndex != nil {
+			return
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			fmt.Fprintf(os.Stderr, "Shutting down gracefully...")
+			return
+		}
+	}
+}

--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -17,29 +17,23 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
-	"os"
-	"os/signal"
-	"strings"
-	"syscall"
-	"time"
 
 	ctgo "github.com/google/certificate-transparency-go"
 	ctclient "github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
+	"github.com/sigstore/rekor-monitor/cmd"
 	"github.com/sigstore/rekor-monitor/pkg/ct"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/notifications"
-	"gopkg.in/yaml.v2"
 )
 
 // Default values for monitoring job parameters
 const (
 	publicCTServerURL        = "https://ctfe.sigstore.dev/2022"
-	logInfoFileName          = "ctLogInfo.txt"
+	logInfoFileName          = "ctLogInfo"
 	outputIdentitiesFileName = "ctIdentities.txt"
 )
 
@@ -47,40 +41,18 @@ const (
 // Upon starting, any existing latest snapshot data is loaded and the function runs
 // indefinitely to perform identity search for every time interval that was specified.
 func main() {
-	configFilePath := flag.String("config-file", "", "path to yaml configuration file containing identity monitor settings")
-	configYamlInput := flag.String("config", "", "string with YAML configuration containing identity monitor settings")
-	once := flag.Bool("once", true, "whether to run the monitor on a repeated interval or once")
-	logInfoFile := flag.String("file", logInfoFileName, "path to the initial log info checkpoint file to be read from")
-	serverURL := flag.String("url", publicCTServerURL, "URL to the public CT server that is to be monitored")
-	interval := flag.Duration("interval", 5*time.Minute, "Length of interval between each periodical consistency check")
-	flag.Parse()
-
-	var config notifications.IdentityMonitorConfiguration
-
-	if *configFilePath != "" && *configYamlInput != "" {
-		log.Fatalf("error: only one of --config and --config-file should be specified")
+	flags, config, err := cmd.ParseAndLoadConfig(publicCTServerURL, logInfoFileName, outputIdentitiesFileName, "ct-monitor")
+	if err != nil {
+		log.Fatalf("error parsing flags and loading config: %v", err)
+	}
+	if flags.LogInfoFile == "" {
+		logInfoFileName := fmt.Sprintf("%s.txt", logInfoFileName)
+		flags.LogInfoFile = logInfoFileName
 	}
 
-	if *configFilePath != "" {
-		readConfig, err := os.ReadFile(*configFilePath)
-		if err != nil {
-			log.Fatalf("error reading from identity monitor configuration file: %v", err)
-		}
-
-		configString := string(readConfig)
-		if err := yaml.Unmarshal([]byte(configString), &config); err != nil {
-			log.Fatalf("error parsing identities: %v", err)
-		}
-	}
-
-	if *configYamlInput != "" {
-		if err := yaml.Unmarshal([]byte(*configYamlInput), &config); err != nil {
-			log.Fatalf("error parsing identities: %v", err)
-		}
-	}
-
-	var fulcioClient *ctclient.LogClient
-	fulcioClient, err := ctclient.New(*serverURL, http.DefaultClient, jsonclient.Options{})
+	fulcioClient, err := ctclient.New(flags.ServerURL, http.DefaultClient, jsonclient.Options{
+		UserAgent: flags.UserAgent,
+	})
 	if err != nil {
 		log.Fatalf("getting Fulcio client: %v", err)
 	}
@@ -95,87 +67,39 @@ func main() {
 		OIDMatchers:           allOIDMatchers,
 	}
 
-	for _, certID := range monitoredValues.CertificateIdentities {
-		if len(certID.Issuers) == 0 {
-			fmt.Printf("Monitoring certificate subject %s\n", certID.CertSubject)
-		} else {
-			fmt.Printf("Monitoring certificate subject %s for issuer(s) %s\n", certID.CertSubject, strings.Join(certID.Issuers, ","))
-		}
-	}
-	for _, fp := range monitoredValues.Fingerprints {
-		fmt.Printf("Monitoring fingerprint %s\n", fp)
-	}
-	for _, sub := range monitoredValues.Subjects {
-		fmt.Printf("Monitoring subject %s\n", sub)
-	}
-
-	ticker := time.NewTicker(*interval)
-	defer ticker.Stop()
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
-
-	// To get an immediate first tick, for-select is at the end of the loop
-	for {
-		inputEndIndex := config.EndIndex
-
-		// TODO: Handle Rekor sharding
-		// https://github.com/sigstore/rekor-monitor/issues/57
-		var prevSTH *ctgo.SignedTreeHead
-		prevSTH, currentSTH, err := ct.RunConsistencyCheck(fulcioClient, *logInfoFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to successfully complete consistency check: %v", err)
-			return
-		}
-
-		if config.StartIndex == nil {
-			if prevSTH != nil {
-				checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
-				config.StartIndex = &checkpointStartIndex
-			} else {
-				defaultStartIndex := 0
-				config.StartIndex = &defaultStartIndex
+	cmd.PrintMonitoredValues(monitoredValues)
+	cmd.LoopLogs(cmd.LoopLogsParams{
+		Interval:        flags.Interval,
+		Config:          config,
+		MonitoredValues: monitoredValues,
+		Once:            flags.Once,
+		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.Checkpoint, error) {
+			prev, cur, err := ct.RunConsistencyCheck(fulcioClient, flags.LogInfoFile)
+			if err != nil {
+				return nil, nil, err
 			}
-		}
-
-		if config.EndIndex == nil {
+			var prevCheckpoint cmd.Checkpoint
+			if prev != nil {
+				prevCheckpoint = prev
+			}
+			var curCheckpoint cmd.Checkpoint
+			if cur != nil {
+				curCheckpoint = cur
+			}
+			return prevCheckpoint, curCheckpoint, nil
+		},
+		GetStartIndexFn: func(prev, _ cmd.Checkpoint) *int {
+			prevSTH := prev.(*ctgo.SignedTreeHead)
+			checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
+			return &checkpointStartIndex
+		},
+		GetEndIndexFn: func(_, cur cmd.Checkpoint) *int {
+			currentSTH := cur.(*ctgo.SignedTreeHead)
 			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
-			config.EndIndex = &checkpointEndIndex
-		}
-
-		if *config.StartIndex >= *config.EndIndex {
-			fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
-		}
-
-		if identity.MonitoredValuesExist(monitoredValues) {
-			foundEntries, err := ct.IdentitySearch(context.Background(), fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, outputIdentitiesFileName, nil)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
-				return
-			}
-
-			notificationPool := notifications.CreateNotificationPool(config)
-
-			err = notifications.TriggerNotifications(notificationPool, foundEntries)
-			if err != nil {
-				// continue running consistency check if notifications fail to trigger
-				fmt.Fprintf(os.Stderr, "failed to trigger notifications: %v", err)
-			}
-		}
-
-		if *once || inputEndIndex != nil {
-			return
-		}
-
-		config.StartIndex = config.EndIndex
-		config.EndIndex = nil
-
-		select {
-		case <-ticker.C:
-			continue
-		case <-signalChan:
-			fmt.Fprintf(os.Stderr, "received signal, exiting")
-			return
-		}
-	}
+			return &checkpointEndIndex
+		},
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+			return ct.IdentitySearch(ctx, fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
+		},
+	})
 }

--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -24,7 +24,7 @@ import (
 	ctgo "github.com/google/certificate-transparency-go"
 	ctclient "github.com/google/certificate-transparency-go/client"
 	"github.com/google/certificate-transparency-go/jsonclient"
-	"github.com/sigstore/rekor-monitor/cmd"
+	"github.com/sigstore/rekor-monitor/internal/cmd"
 	"github.com/sigstore/rekor-monitor/pkg/ct"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/notifications"
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	cmd.PrintMonitoredValues(monitoredValues)
-	cmd.LoopLogs(cmd.LoopLogsParams{
+	cmd.MonitorLoop(cmd.MonitorLoopParams{
 		Interval:        flags.Interval,
 		Config:          config,
 		MonitoredValues: monitoredValues,

--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -73,7 +73,7 @@ func main() {
 		Config:          config,
 		MonitoredValues: monitoredValues,
 		Once:            flags.Once,
-		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.Checkpoint, error) {
+		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
 			prev, cur, err := ct.RunConsistencyCheck(fulcioClient, flags.LogInfoFile)
 			if err != nil {
 				return nil, nil, err
@@ -82,18 +82,18 @@ func main() {
 			if prev != nil {
 				prevCheckpoint = prev
 			}
-			var curCheckpoint cmd.Checkpoint
+			var curLogInfo cmd.LogInfo
 			if cur != nil {
-				curCheckpoint = cur
+				curLogInfo = cur
 			}
-			return prevCheckpoint, curCheckpoint, nil
+			return prevCheckpoint, curLogInfo, nil
 		},
-		GetStartIndexFn: func(prev, _ cmd.Checkpoint) *int {
+		GetStartIndexFn: func(prev cmd.Checkpoint, _ cmd.LogInfo) *int {
 			prevSTH := prev.(*ctgo.SignedTreeHead)
 			checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
 			return &checkpointStartIndex
 		},
-		GetEndIndexFn: func(_, cur cmd.Checkpoint) *int {
+		GetEndIndexFn: func(_ cmd.Checkpoint, cur cmd.LogInfo) *int {
 			currentSTH := cur.(*ctgo.SignedTreeHead)
 			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
 			return &checkpointEndIndex

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -21,7 +21,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/sigstore/rekor-monitor/cmd"
+	"github.com/sigstore/rekor-monitor/internal/cmd"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/notifications"
 	rekor_v1 "github.com/sigstore/rekor-monitor/pkg/rekor/v1"
@@ -128,7 +128,7 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 	}
 
 	cmd.PrintMonitoredValues(monitoredValues)
-	cmd.LoopLogs(cmd.LoopLogsParams{
+	cmd.MonitorLoop(cmd.MonitorLoopParams{
 		Interval:        flags.Interval,
 		Config:          config,
 		MonitoredValues: monitoredValues,
@@ -167,7 +167,7 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 }
 
 func mainLoopV2(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorConfiguration, rekorShards map[string]rekor_v2.ShardInfo, activeShardOrigin string) {
-	cmd.LoopLogs(cmd.LoopLogsParams{
+	cmd.MonitorLoop(cmd.MonitorLoopParams{
 		Interval:        flags.Interval,
 		Config:          config,
 		MonitoredValues: identity.MonitoredValues{},

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -17,16 +17,11 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
-	"runtime"
-	"strings"
-	"syscall"
-	"time"
 
+	"github.com/sigstore/rekor-monitor/cmd"
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/sigstore/rekor-monitor/pkg/notifications"
 	rekor_v1 "github.com/sigstore/rekor-monitor/pkg/rekor/v1"
@@ -36,8 +31,6 @@ import (
 	"github.com/sigstore/rekor/pkg/util"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
-	"gopkg.in/yaml.v2"
-	"sigs.k8s.io/release-utils/version"
 )
 
 // Default values for monitoring job parameters
@@ -52,48 +45,13 @@ const (
 // Upon starting, any existing latest snapshot data is loaded and the function runs
 // indefinitely to perform identity search for every time interval that was specified.
 func main() {
-	// Command-line flags that are parameters to the verifier job
-	configFilePath := flag.String("config-file", "", "path to yaml configuration file containing identity monitor settings")
-	configYamlInput := flag.String("config", "", "string with YAML configuration containing identity monitor settings")
-	once := flag.Bool("once", true, "whether to run the monitor on a repeated interval or once")
-	serverURL := flag.String("url", publicRekorServerURL, "URL to the rekor server that is to be monitored")
-	logInfoFile := flag.String("file", "", "path to the initial log info checkpoint file to be read from")
-	interval := flag.Duration("interval", 5*time.Minute, "Length of interval between each periodical consistency check")
-	userAgentString := flag.String("user-agent", "", "details to include in the user agent string")
-	tufRepository := flag.String("tuf-repository", TUFRepository, "TUF repository to use. Can be 'default' or 'staging'")
-	flag.Parse()
-
-	var config notifications.IdentityMonitorConfiguration
-
-	if *configFilePath != "" && *configYamlInput != "" {
-		log.Fatalf("error: only one of --config and --config-file should be specified")
-	}
-
-	if *configFilePath != "" {
-		readConfig, err := os.ReadFile(*configFilePath)
-		if err != nil {
-			log.Fatalf("error reading from identity monitor configuration file: %v", err)
-		}
-
-		configString := string(readConfig)
-		if err := yaml.Unmarshal([]byte(configString), &config); err != nil {
-			log.Fatalf("error parsing identities: %v", err)
-		}
-	}
-
-	if *configYamlInput != "" {
-		if err := yaml.Unmarshal([]byte(*configYamlInput), &config); err != nil {
-			log.Fatalf("error parsing identities: %v", err)
-		}
-	}
-
-	if config.OutputIdentitiesFile == "" {
-		config.OutputIdentitiesFile = outputIdentitiesFileName
+	flags, config, err := cmd.ParseAndLoadConfig(publicRekorServerURL, TUFRepository, outputIdentitiesFileName, "rekor-monitor")
+	if err != nil {
+		log.Fatalf("error parsing flags and loading config: %v", err)
 	}
 
 	var tufClient *tuf.Client
-	var err error
-	switch *tufRepository {
+	switch flags.TUFRepository {
 	case "default":
 		tufClient, err = tuf.DefaultClient()
 	case "staging":
@@ -101,7 +59,6 @@ func main() {
 		tufClient, err = tuf.New(options)
 	default:
 		log.Fatalf("custom TUF repository not currently supported")
-
 	}
 	if err != nil {
 		log.Fatal(err)
@@ -124,34 +81,31 @@ func main() {
 	allRekorServices := signingConfig.RekorLogURLs()
 	rekorVersion := uint32(1)
 	for _, service := range allRekorServices {
-		if *serverURL == service.URL {
+		if flags.ServerURL == service.URL {
 			rekorVersion = service.MajorAPIVersion
 		}
 	}
-	if *logInfoFile == "" {
+	if flags.LogInfoFile == "" {
 		logInfoFileName := fmt.Sprintf("%s.v%d.txt", logInfoFileNamePrefix, rekorVersion)
-		logInfoFile = &logInfoFileName
+		flags.LogInfoFile = logInfoFileName
 	}
-	userAgent := strings.TrimSpace(fmt.Sprintf("rekor-monitor/%s (%s; %s) %s", version.GetVersionInfo().GitVersion, runtime.GOOS, runtime.GOARCH, *userAgentString))
 	switch rekorVersion {
 	case 1:
-		mainLoopV1(*serverURL, *once, *logInfoFile, *interval, userAgent, config, trustedRoot)
-		return
+		mainLoopV1(flags, config, trustedRoot)
 	case 2:
 		fmt.Fprintf(os.Stderr, "Warning: the monitor currently only checks for the consistency of the log in Rekor v2 logs.\n")
-		rekorShards, activeShardOrigin, err := rekor_v2.GetRekorShards(context.Background(), trustedRoot, allRekorServices, userAgent)
+		rekorShards, activeShardOrigin, err := rekor_v2.GetRekorShards(context.Background(), trustedRoot, allRekorServices, flags.UserAgent)
 		if err != nil {
 			log.Fatal(err)
 		}
-		mainLoopV2(*once, *logInfoFile, *interval, rekorShards, activeShardOrigin)
-		return
+		mainLoopV2(flags, config, rekorShards, activeShardOrigin)
 	default:
 		log.Fatalf("Unsupported server version %v, only '1' and '2' are supported", rekorVersion)
 	}
 }
 
-func mainLoopV1(serverURL string, once bool, logInfoFile string, interval time.Duration, userAgent string, config notifications.IdentityMonitorConfiguration, trustedRoot *root.TrustedRoot) {
-	rekorClient, err := client.GetRekorClient(serverURL, client.WithUserAgent(userAgent))
+func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorConfiguration, trustedRoot *root.TrustedRoot) {
+	rekorClient, err := client.GetRekorClient(flags.ServerURL, client.WithUserAgent(flags.UserAgent))
 	if err != nil {
 		log.Fatalf("getting Rekor client: %v", err)
 	}
@@ -173,116 +127,71 @@ func mainLoopV1(serverURL string, once bool, logInfoFile string, interval time.D
 		OIDMatchers:           allOIDMatchers,
 	}
 
-	for _, certID := range monitoredValues.CertificateIdentities {
-		if len(certID.Issuers) == 0 {
-			fmt.Printf("Monitoring certificate subject %s\n", certID.CertSubject)
-		} else {
-			fmt.Printf("Monitoring certificate subject %s for issuer(s) %s\n", certID.CertSubject, strings.Join(certID.Issuers, ","))
-		}
-	}
-	for _, fp := range monitoredValues.Fingerprints {
-		fmt.Printf("Monitoring fingerprint %s\n", fp)
-	}
-	for _, sub := range monitoredValues.Subjects {
-		fmt.Printf("Monitoring subject %s\n", sub)
-	}
-
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	// To get an immediate first tick, for-select is at the end of the loop
-	for {
-		inputEndIndex := config.EndIndex
-
-		// TODO: Handle Rekor sharding
-		// https://github.com/sigstore/rekor-monitor/issues/57
-		var logInfo *models.LogInfo
-		var prevCheckpoint *util.SignedCheckpoint
-		prevCheckpoint, logInfo, err = rekor_v1.RunConsistencyCheck(rekorClient, verifier, logInfoFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
-			return
-		}
-
-		if config.StartIndex == nil {
-			if prevCheckpoint != nil {
-				checkpointStartIndex := rekor_v1.GetCheckpointIndex(logInfo, prevCheckpoint)
-				config.StartIndex = &checkpointStartIndex
-			} else {
-				fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint")
-				return
-			}
-		}
-
-		if config.EndIndex == nil {
-			checkpoint, err := rekor_v1.ReadLatestCheckpoint(logInfo)
+	cmd.PrintMonitoredValues(monitoredValues)
+	cmd.LoopLogs(cmd.LoopLogsParams{
+		Interval:        flags.Interval,
+		Config:          config,
+		MonitoredValues: monitoredValues,
+		Once:            flags.Once,
+		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.Checkpoint, error) {
+			prev, cur, err := rekor_v1.RunConsistencyCheck(rekorClient, verifier, flags.LogInfoFile)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error reading checkpoint: %v", err)
-				return
+				return nil, nil, err
 			}
-
-			checkpointEndIndex := rekor_v1.GetCheckpointIndex(logInfo, checkpoint)
-			config.EndIndex = &checkpointEndIndex
-		}
-
-		if *config.StartIndex >= *config.EndIndex {
-			fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
-			return
-		}
-
-		if identity.MonitoredValuesExist(monitoredValues) {
-			_, err = rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
+			var prevCheckpoint cmd.Checkpoint
+			if prev != nil {
+				prevCheckpoint = prev
+			}
+			var curCheckpoint cmd.Checkpoint
+			if cur != nil {
+				curCheckpoint = cur
+			}
+			return prevCheckpoint, curCheckpoint, nil
+		},
+		GetStartIndexFn: func(prev, cur cmd.Checkpoint) *int {
+			checkpointStartIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), prev.(*util.SignedCheckpoint))
+			return &checkpointStartIndex
+		},
+		GetEndIndexFn: func(_, cur cmd.Checkpoint) *int {
+			checkpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
-				return
+				return nil
 			}
-		}
-
-		if once || inputEndIndex != nil {
-			return
-		}
-
-		config.StartIndex = config.EndIndex
-		config.EndIndex = nil
-
-		select {
-		case <-ticker.C:
-			continue
-		case <-ctx.Done():
-			fmt.Fprintf(os.Stderr, "Shutting down gracefully...")
-			return
-		}
-	}
+			checkpointEndIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), checkpoint)
+			return &checkpointEndIndex
+		},
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+			return rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
+		},
+	})
 }
 
-func mainLoopV2(once bool, logInfoFile string, interval time.Duration, rekorShards map[string]rekor_v2.ShardInfo, activeShardOrigin string) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
-
-	// To get an immediate first tick, for-select is at the end of the loop
-	for {
-		_, err := rekor_v2.RunConsistencyCheck(context.Background(), rekorShards, activeShardOrigin, logInfoFile)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
-			return
-		}
-
-		if once {
-			return
-		}
-
-		select {
-		case <-ticker.C:
-			continue
-		case <-signalChan:
-			fmt.Fprintf(os.Stderr, "received signal, exiting")
-			return
-		}
-	}
+func mainLoopV2(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorConfiguration, rekorShards map[string]rekor_v2.ShardInfo, activeShardOrigin string) {
+	cmd.LoopLogs(cmd.LoopLogsParams{
+		Interval:        flags.Interval,
+		Config:          config,
+		MonitoredValues: identity.MonitoredValues{},
+		Once:            flags.Once,
+		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.Checkpoint, error) {
+			// TODO: should return prev and cur
+			cur, err := rekor_v2.RunConsistencyCheck(context.Background(), rekorShards, activeShardOrigin, flags.LogInfoFile)
+			if err != nil {
+				return nil, nil, err
+			}
+			var curCheckpoint cmd.Checkpoint
+			if cur != nil {
+				curCheckpoint = cur
+			}
+			return nil, curCheckpoint, nil
+		},
+		GetStartIndexFn: func(_, _ cmd.Checkpoint) *int {
+			return nil
+		},
+		GetEndIndexFn: func(_, _ cmd.Checkpoint) *int {
+			return nil
+		},
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+			return nil, nil
+		},
+	})
 }

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -44,8 +44,8 @@ type MonitorFlags struct {
 	TUFRepository string
 }
 
-// LoopLogsParams contains the parameters for the LoopLogs function
-type LoopLogsParams struct {
+// MonitorLoopParams contains the parameters for the LoopLogs function
+type MonitorLoopParams struct {
 	Interval              time.Duration
 	Config                *notifications.IdentityMonitorConfiguration
 	MonitoredValues       identity.MonitoredValues
@@ -150,7 +150,7 @@ func PrintMonitoredValues(monitoredValues identity.MonitoredValues) {
 	}
 }
 
-func LoopLogs(params LoopLogsParams) {
+func MonitorLoop(params MonitorLoopParams) {
 	ticker := time.NewTicker(params.Interval)
 	defer ticker.Stop()
 

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -50,13 +50,14 @@ type MonitorLoopParams struct {
 	Config                *notifications.IdentityMonitorConfiguration
 	MonitoredValues       identity.MonitoredValues
 	Once                  bool
-	RunConsistencyCheckFn func(ctx context.Context) (Checkpoint, Checkpoint, error)
-	GetStartIndexFn       func(prev, cur Checkpoint) *int
-	GetEndIndexFn         func(prev, cur Checkpoint) *int
+	RunConsistencyCheckFn func(ctx context.Context) (Checkpoint, LogInfo, error)
+	GetStartIndexFn       func(prev Checkpoint, cur LogInfo) *int
+	GetEndIndexFn         func(prev Checkpoint, cur LogInfo) *int
 	IdentitySearchFn      func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error)
 }
 
 type Checkpoint interface{}
+type LogInfo interface{}
 
 // ParseMonitorFlags parses command-line flags and returns a MonitorFlags struct
 func ParseMonitorFlags(defaultServerURL, defaultTUFRepository string, baseUserAgentName string) *MonitorFlags {


### PR DESCRIPTION
#### Summary
Until now, ct-monitor and rekor-monitor were duplicating a lot of code to perform the loop, check various arguments, print data, etc. The result was that changes implemented in one implementation did not get always ported to the other. These changes refactor that code in a `common.go` file that implements the main loop over the logs (CT or Rekor).