### PR TITLE
Fix once behaviour

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -93,7 +93,7 @@ func main() {
 			checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
 			return &checkpointStartIndex
 		},
-		GetEndIndexFn: func(_ cmd.Checkpoint, cur cmd.LogInfo) *int {
+		GetEndIndexFn: func(cur cmd.LogInfo) *int {
 			currentSTH := cur.(*ctgo.SignedTreeHead)
 			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
 			return &checkpointEndIndex

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -152,7 +152,7 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 			checkpointStartIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), prev.(*util.SignedCheckpoint))
 			return &checkpointStartIndex
 		},
-		GetEndIndexFn: func(_ cmd.Checkpoint, cur cmd.LogInfo) *int {
+		GetEndIndexFn: func(cur cmd.LogInfo) *int {
 			checkpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
 			if err != nil {
 				return nil
@@ -187,7 +187,7 @@ func mainLoopV2(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 		GetStartIndexFn: func(_ cmd.Checkpoint, _ cmd.LogInfo) *int {
 			return nil
 		},
-		GetEndIndexFn: func(_ cmd.Checkpoint, _ cmd.LogInfo) *int {
+		GetEndIndexFn: func(_ cmd.LogInfo) *int {
 			return nil
 		},
 		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -176,8 +176,8 @@ func MonitorLoop(params MonitorLoopParams) {
 				if prevCheckpoint != nil {
 					config.StartIndex = params.GetStartIndexFn(prevCheckpoint, curCheckpoint)
 				} else {
-					fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint")
-					return
+					fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint, saving checkpoint and continuing\n")
+					continue
 				}
 			}
 
@@ -185,8 +185,8 @@ func MonitorLoop(params MonitorLoopParams) {
 				config.EndIndex = params.GetEndIndexFn(prevCheckpoint, curCheckpoint)
 			}
 
-			if *config.StartIndex >= *config.EndIndex {
-				fmt.Fprintf(os.Stderr, "start index %d must be strictly less than end index %d", *config.StartIndex, *config.EndIndex)
+			if *config.StartIndex > *config.EndIndex {
+				fmt.Fprintf(os.Stderr, "start index %d must be less or equal than end index %d", *config.StartIndex, *config.EndIndex)
 				return
 			}
 

--- a/pkg/rekor/v1/client.go
+++ b/pkg/rekor/v1/client.go
@@ -49,11 +49,6 @@ func GetEntriesByIndexRange(ctx context.Context, rekorClient *client.Rekor, star
 		return nil, fmt.Errorf("start (%d) must be less than or equal to end (%d)", start, end)
 	}
 
-	// handle case where we initialize log monitor
-	if start == end {
-		start--
-	}
-
 	var logEntries []models.LogEntry
 	for i := start + 1; i <= end; i += 10 {
 		select {

--- a/pkg/rekor/v1/client_test.go
+++ b/pkg/rekor/v1/client_test.go
@@ -95,16 +95,25 @@ func TestGetEntriesByIndexRange(t *testing.T) {
 		index++
 	}
 
-	// should return index 42
+	// should return 0 entries for index range where start == end
 	result, err = GetEntriesByIndexRange(context.TODO(), &mClient, 42, 42)
+	if err != nil {
+		t.Fatalf("unexpected error getting entries: %v", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("expected 0 entry, got %d", len(result))
+	}
+
+	// should return index 43
+	result, err = GetEntriesByIndexRange(context.TODO(), &mClient, 42, 43)
 	if err != nil {
 		t.Fatalf("unexpected error getting entries: %v", err)
 	}
 	if len(result) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(result))
 	}
-	if !reflect.DeepEqual(result[0], *logEntries[42]) {
-		t.Fatalf("entries should be equal for index 0, log index 42")
+	if !reflect.DeepEqual(result[0], *logEntries[43]) {
+		t.Fatalf("entries should be equal for index 0, log index 43, got %v", result[0])
 	}
 
 	// failure: start greater than end


### PR DESCRIPTION
#### Summary
* when using `once=false` flag, the loop should not terminate, even if
  the monitor is executed for the first time
* when there are no new entries in the log (thus startIndex==endIndex),
  the loop should not exit either (code partially borrowed from @fghanmi
  at https://github.com/sigstore/rekor-monitor/pull/700)

#### Release Note
* ct/rekor-monitors do not stop early when `-once=false` is used, even when they are run for the first time.
* ct/rekor-monitors do not stop early if there are no new log entries in the log