### PR TITLE
pkg/notifications: make Notifications more customazible

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -69,10 +69,11 @@ func main() {
 
 	cmd.PrintMonitoredValues(monitoredValues)
 	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:        flags.Interval,
-		Config:          config,
-		MonitoredValues: monitoredValues,
-		Once:            flags.Once,
+		Interval:                 flags.Interval,
+		Config:                   config,
+		MonitoredValues:          monitoredValues,
+		Once:                     flags.Once,
+		NotificationContextNewFn: notifications.CreateCTMonitorNotificationContext,
 		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
 			prev, cur, err := ct.RunConsistencyCheck(fulcioClient, flags.LogInfoFile)
 			if err != nil {

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -150,10 +150,11 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 
 	cmd.PrintMonitoredValues(monitoredValues)
 	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:        flags.Interval,
-		Config:          config,
-		MonitoredValues: monitoredValues,
-		Once:            flags.Once,
+		Interval:                 flags.Interval,
+		Config:                   config,
+		MonitoredValues:          monitoredValues,
+		Once:                     flags.Once,
+		NotificationContextNewFn: notifications.CreateRekorMonitorNotificationContext,
 		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
 			prev, cur, err := rekor_v1.RunConsistencyCheck(rekorClient, verifier, flags.LogInfoFile)
 			if err != nil {
@@ -189,10 +190,11 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 
 func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifications.IdentityMonitorConfiguration, rekorShards map[string]rekor_v2.ShardInfo, latestShardOrigin string) {
 	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:        flags.Interval,
-		Config:          config,
-		MonitoredValues: identity.MonitoredValues{},
-		Once:            flags.Once,
+		Interval:                 flags.Interval,
+		Config:                   config,
+		MonitoredValues:          identity.MonitoredValues{},
+		Once:                     flags.Once,
+		NotificationContextNewFn: notifications.CreateRekorMonitorNotificationContext,
 		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
 			// On each iteration, we refresh the SigningConfig metadata and
 			// update the shards if we detect a change in the newest shard

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -101,6 +101,18 @@ func PrintMonitoredIdentities(monitoredIdentities []MonitoredIdentity) ([]byte, 
 	return jsonBody, nil
 }
 
+// MonitoredIdentityList wraps []MonitoredIdentity to implement NotificationBodyConverter
+type MonitoredIdentityList []MonitoredIdentity
+
+// ToNotificationBody implements the NotificationBodyConverter interface for MonitoredIdentityList
+func (identities MonitoredIdentityList) ToNotificationBody() (string, error) {
+	jsonBody, err := json.MarshalIndent(identities, "", "\t")
+	if err != nil {
+		return "", err
+	}
+	return string(jsonBody), nil
+}
+
 // CreateIdentitiesList takes in a MonitoredValues input and returns a list of all currently monitored identities.
 // It returns a list of strings.
 func CreateIdentitiesList(mvs MonitoredValues) []string {

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -17,7 +17,6 @@ package notifications
 import (
 	"context"
 
-	"github.com/sigstore/rekor-monitor/pkg/identity"
 	"github.com/wneessen/go-mail"
 )
 
@@ -32,18 +31,17 @@ type EmailNotificationInput struct {
 	SMTPCustomOptions     []mail.Option `yaml:"SMTPCustomOptions"`
 }
 
-func GenerateEmailBody(monitoredIdentities []identity.MonitoredIdentity) (string, error) {
-	body, err := identity.PrintMonitoredIdentities(monitoredIdentities)
+// generateEmailBody generates email body for generic notification data
+func generateEmailBody(data NotificationData) (string, error) {
+	body, err := data.Payload.ToNotificationBody()
 	if err != nil {
 		return "", err
 	}
-	return "<pre>" + string(body) + "</pre>", nil
+	return "<pre>" + body + "</pre>", nil
 }
 
-// Send takes in an EmailNotification input and attempts to send the
-// following list of found identities to the given email address.
-// It returns an error in the case of failure.
-func (emailNotificationInput EmailNotificationInput) Send(ctx context.Context, monitoredIdentities []identity.MonitoredIdentity) error {
+// Send implements the NotificationPlatform interface
+func (emailNotificationInput EmailNotificationInput) Send(ctx context.Context, data NotificationData) error {
 	email := mail.NewMsg()
 	if err := email.From(emailNotificationInput.SenderEmailAddress); err != nil {
 		return err
@@ -51,9 +49,9 @@ func (emailNotificationInput EmailNotificationInput) Send(ctx context.Context, m
 	if err := email.To(emailNotificationInput.RecipientEmailAddress); err != nil {
 		return err
 	}
-	emailSubject := NotificationSubject
+	emailSubject := data.Context.Subject
 	email.Subject(emailSubject)
-	emailBody, err := GenerateEmailBody(monitoredIdentities)
+	emailBody, err := generateEmailBody(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/email_test.go
+++ b/pkg/notifications/email_test.go
@@ -67,7 +67,11 @@ func TestEmailSendFailureCases(t *testing.T) {
 	}
 
 	for _, emailNotificationInput := range emailNotificationInputs {
-		err := emailNotificationInput.Send(context.Background(), []identity.MonitoredIdentity{monitoredIdentity})
+		notificationData := NotificationData{
+			Context: CreateRekorMonitorNotificationContext(),
+			Payload: identity.MonitoredIdentityList{monitoredIdentity},
+		}
+		err := emailNotificationInput.Send(context.Background(), notificationData)
 		if err == nil {
 			t.Errorf("expected error, received nil")
 		}
@@ -98,7 +102,11 @@ func TestEmailSendMockSMTPServerSuccess(t *testing.T) {
 		SMTPCustomOptions:     []mail.Option{mail.WithPort(server.PortNumber()), mail.WithTLSPolicy(mail.NoTLS), mail.WithHELO("example.com")},
 	}
 
-	err := emailNotificationInput.Send(context.Background(), []identity.MonitoredIdentity{monitoredIdentity})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+	}
+	err := emailNotificationInput.Send(context.Background(), notificationData)
 	if err != nil {
 		t.Errorf("expected nil, received error %v", err)
 	}
@@ -129,7 +137,11 @@ func TestEmailSendMockSMTPServerFailure(t *testing.T) {
 		SMTPCustomOptions:     []mail.Option{mail.WithPort(server.PortNumber()), mail.WithTLSPolicy(mail.NoTLS), mail.WithHELO("example.com")},
 	}
 
-	err := emailNotificationInput.Send(context.Background(), []identity.MonitoredIdentity{monitoredIdentity})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+	}
+	err := emailNotificationInput.Send(context.Background(), notificationData)
 	if err == nil || !strings.Contains(err.Error(), "421 Service not available") {
 		t.Errorf("expected 421 Service not available, received error %v", err)
 	}

--- a/pkg/notifications/github_issues.go
+++ b/pkg/notifications/github_issues.go
@@ -16,15 +16,14 @@ package notifications
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v65/github"
-	"github.com/sigstore/rekor-monitor/pkg/identity"
 )
 
 var (
-	notificationPlatformGitHubIssueBodyHeaderText = "Rekor-monitor found the following pairs of monitored identities and matching log entries: "
-	notificationPlatformGitHubIssueLabels         = []string{"rekor-monitor", "automatically generated"}
+	notificationPlatformGitHubIssueBodyHeaderText = "%s found the following pairs of monitored identities and matching log entries: "
 )
 
 // GitHubIssueInput extends the NotificationPlatform interface to support found identity
@@ -41,31 +40,34 @@ type GitHubIssueInput struct {
 	GitHubClient *github.Client `yaml:"githubClient"`
 }
 
-func generateGitHubIssueBody(monitoredIdentities []identity.MonitoredIdentity) (string, error) {
-	header := notificationPlatformGitHubIssueBodyHeaderText
-	body, err := identity.PrintMonitoredIdentities(monitoredIdentities)
+// generateGitHubIssueBody generates a GitHub issue body for generic notification data
+func generateGitHubIssueBody(data NotificationData) (string, error) {
+	// Use custom header if available in metadata, otherwise use default
+	header := fmt.Sprintf(notificationPlatformGitHubIssueBodyHeaderText, data.Context.MonitorType)
+
+	// Try to use the payload as a NotificationBodyConverter
+	body, err := data.Payload.ToNotificationBody()
 	if err != nil {
 		return "", err
 	}
-	return strings.Join([]string{header, "```\n" + string(body) + "\n```"}, "\n"), nil
+	return strings.Join([]string{header, "```\n" + body + "\n```"}, "\n"), nil
 }
 
-// Send takes in a GitHubIssueInput and attempts to create the specified issue
-// denoting the following found identities.
-// It returns an error in the case of failure.
-func (gitHubIssueInput GitHubIssueInput) Send(ctx context.Context, monitoredIdentities []identity.MonitoredIdentity) error {
-	issueTitle := NotificationSubject
-	issueBody, err := generateGitHubIssueBody(monitoredIdentities)
+// Send implements the NotificationPlatform interface
+func (gitHubIssueInput GitHubIssueInput) Send(ctx context.Context, data NotificationData) error {
+	issueTitle := data.Context.Subject
+	issueBody, err := generateGitHubIssueBody(data)
 	if err != nil {
 		return err
 	}
+
 	var client *github.Client
 	if gitHubIssueInput.GitHubClient == nil {
 		client = github.NewClient(nil).WithAuthToken(gitHubIssueInput.AuthenticationToken)
 	} else {
 		client = gitHubIssueInput.GitHubClient
 	}
-	labels := notificationPlatformGitHubIssueLabels
+	labels := []string{data.Context.MonitorType, "automatically generated"}
 
 	issueRequest := &github.IssueRequest{
 		Title:    &issueTitle,

--- a/pkg/notifications/github_issues_test.go
+++ b/pkg/notifications/github_issues_test.go
@@ -34,7 +34,11 @@ func TestGitHubIssueInputSend401BadCredentialsFailure(t *testing.T) {
 		AuthenticationToken: "",
 	}
 	ctx := context.Background()
-	err := gitHubIssuesInput.Send(ctx, []identity.MonitoredIdentity{})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{},
+	}
+	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err == nil {
 		t.Errorf("expected 401 Bad Credentials, received error %v", err)
 	}
@@ -67,7 +71,11 @@ func TestGitHubIssueInputMockSendSuccess(t *testing.T) {
 		GitHubClient:        mockGitHubClient,
 	}
 	ctx := context.Background()
-	err := gitHubIssuesInput.Send(ctx, []identity.MonitoredIdentity{})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{},
+	}
+	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err != nil {
 		t.Errorf("expected nil, received error %v", err)
 	}
@@ -95,7 +103,11 @@ func TestGitHubIssueInputMockSendFailure(t *testing.T) {
 		GitHubClient:        mockGitHubClient,
 	}
 	ctx := context.Background()
-	err := gitHubIssuesInput.Send(ctx, []identity.MonitoredIdentity{})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{},
+	}
+	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err == nil || !strings.Contains(err.Error(), "400 Bad Request") {
 		t.Errorf("expected 400 Bad Request, received %v", err)
 	}

--- a/pkg/notifications/mailgun.go
+++ b/pkg/notifications/mailgun.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/mailgun/mailgun-go/v4"
-	"github.com/sigstore/rekor-monitor/pkg/identity"
 )
 
 // MailgunNotificationInput extends the NotificationPlatform interface to support
@@ -30,12 +29,10 @@ type MailgunNotificationInput struct {
 	MailgunDomainName     string `yaml:"mailgunDomainName"`
 }
 
-// Send takes in an MailgunNotificationInput and attempts to send the
-// following list of found identities to the given email address.
-// It returns an error in the case of failure.
-func (mailgunNotificationInput MailgunNotificationInput) Send(ctx context.Context, monitoredIdentities []identity.MonitoredIdentity) error {
-	subject := NotificationSubject
-	emailHTMLBody, err := GenerateEmailBody(monitoredIdentities)
+// Send implements the NotificationPlatform interface
+func (mailgunNotificationInput MailgunNotificationInput) Send(ctx context.Context, data NotificationData) error {
+	subject := data.Context.Subject
+	emailHTMLBody, err := generateEmailBody(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/mailgun_test.go
+++ b/pkg/notifications/mailgun_test.go
@@ -39,7 +39,11 @@ func TestMailgunSendFailure(t *testing.T) {
 		},
 	}
 
-	err := mailgunNotificationInput.Send(context.Background(), []identity.MonitoredIdentity{monitoredIdentity})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+	}
+	err := mailgunNotificationInput.Send(context.Background(), notificationData)
 	if err == nil {
 		t.Errorf("expected error, received nil")
 	}

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -30,14 +30,37 @@ import (
 	"github.com/sigstore/rekor-monitor/pkg/identity"
 )
 
-var (
-	NotificationSubject = fmt.Sprintf("rekor-monitor workflow results for %s", time.Now().Format(time.RFC822))
-)
+type NotificationContextNew func() NotificationContext
+
+// NotificationContext provides context information for notifications
+type NotificationContext struct {
+	MonitorType string `json:"monitorType"` // e.g., "rekor-monitor", "ct-monitor"
+	Subject     string `json:"subject"`     // Custom subject line
+}
+
+// NotificationBodyConverter defines an interface for payloads that can convert themselves to a notification body string
+type NotificationBodyConverter interface {
+	ToNotificationBody() (string, error)
+}
+
+// NotificationData represents the data to be sent in a notification
+type NotificationData struct {
+	Context NotificationContext       `json:"context"`
+	Payload NotificationBodyConverter `json:"payload"` // The actual data to notify about
+}
 
 // NotificationPlatform provides the Send() method to handle alerting logic
 // for the respective notification platform extending the interface.
 type NotificationPlatform interface {
-	Send(context.Context, []identity.MonitoredIdentity) error
+	Send(context.Context, NotificationData) error
+}
+
+// CreateNotificationContext creates a custom notification context
+func CreateNotificationContext(monitorType, subject string) NotificationContext {
+	return NotificationContext{
+		MonitorType: monitorType,
+		Subject:     subject,
+	}
 }
 
 // ConfigMonitoredValues holds a set of values to compare against a given entry.
@@ -100,13 +123,29 @@ func CreateNotificationPool(config IdentityMonitorConfiguration) []NotificationP
 	return notificationPlatforms
 }
 
-func TriggerNotifications(notificationPlatforms []NotificationPlatform, identities []identity.MonitoredIdentity) error {
+func TriggerNotifications(notificationPlatforms []NotificationPlatform, data NotificationData) error {
 	// update this as new notification platforms are implemented within rekor-monitor
 	for _, notificationPlatform := range notificationPlatforms {
-		if err := notificationPlatform.Send(context.Background(), identities); err != nil {
+		if err := notificationPlatform.Send(context.Background(), data); err != nil {
 			return fmt.Errorf("error sending notification from platform: %v", err)
 		}
 	}
 
 	return nil
+}
+
+// CreateCTMonitorNotificationContext creates a notification context for ct-monitor
+func CreateCTMonitorNotificationContext() NotificationContext {
+	return CreateNotificationContext(
+		"ct-monitor",
+		fmt.Sprintf("ct-monitor workflow results for %s", time.Now().Format(time.RFC822)),
+	)
+}
+
+// CreateRekorMonitorNotificationContext creates a notification context for rekor-monitor
+func CreateRekorMonitorNotificationContext() NotificationContext {
+	return CreateNotificationContext(
+		"rekor-monitor",
+		fmt.Sprintf("rekor-monitor workflow results for %s", time.Now().Format(time.RFC822)),
+	)
 }

--- a/pkg/notifications/notifications_test.go
+++ b/pkg/notifications/notifications_test.go
@@ -26,7 +26,7 @@ import (
 type MockNotificationPlatform struct {
 }
 
-func (mockNotificationPlatform MockNotificationPlatform) Send(_ context.Context, _ []identity.MonitoredIdentity) error {
+func (mockNotificationPlatform MockNotificationPlatform) Send(_ context.Context, _ NotificationData) error {
 	return errors.New("successfully sent from mock notification platform")
 }
 
@@ -52,7 +52,12 @@ func TestCreateAndSendNotifications(t *testing.T) {
 		t.Errorf("expected 2 notification platforms to be created, received %d", notificationPoolLength)
 	}
 
-	err := TriggerNotifications([]NotificationPlatform{mockNotificationPlatform}, []identity.MonitoredIdentity{})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{},
+	}
+
+	err := TriggerNotifications([]NotificationPlatform{mockNotificationPlatform}, notificationData)
 	if !strings.Contains(err.Error(), "successfully sent from mock notification platform") {
 		t.Errorf("did not trigger notification from mock notification platform")
 	}

--- a/pkg/notifications/sendgrid.go
+++ b/pkg/notifications/sendgrid.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/sendgrid/sendgrid-go"
 	"github.com/sendgrid/sendgrid-go/helpers/mail"
-	"github.com/sigstore/rekor-monitor/pkg/identity"
 )
 
 // SendGrid extends the NotificationPlatform interface to support
@@ -32,14 +31,12 @@ type SendGridNotificationInput struct {
 	SendGridAPIKey        string `yaml:"sendGridAPIKey"`
 }
 
-// Send takes in an SendGridNotificationInput and attempts to send the
-// following list of found identities to the given email address.
-// It returns an error in the case of failure.
-func (sendGridNotificationInput SendGridNotificationInput) Send(ctx context.Context, monitoredIdentities []identity.MonitoredIdentity) error {
+// Send implements the NotificationPlatform interface
+func (sendGridNotificationInput SendGridNotificationInput) Send(ctx context.Context, data NotificationData) error {
 	from := mail.NewEmail(sendGridNotificationInput.SenderName, sendGridNotificationInput.SenderEmailAddress)
 	to := mail.NewEmail(sendGridNotificationInput.RecipientName, sendGridNotificationInput.RecipientEmailAddress)
-	subject := NotificationSubject
-	emailHTMLBody, err := GenerateEmailBody(monitoredIdentities)
+	subject := data.Context.Subject
+	emailHTMLBody, err := generateEmailBody(data)
 	if err != nil {
 		return err
 	}

--- a/pkg/notifications/sendgrid_test.go
+++ b/pkg/notifications/sendgrid_test.go
@@ -40,7 +40,11 @@ func TestSendGridSendFailure(t *testing.T) {
 		},
 	}
 
-	err := sendGridNotificationInput.Send(context.Background(), []identity.MonitoredIdentity{monitoredIdentity})
+	notificationData := NotificationData{
+		Context: CreateRekorMonitorNotificationContext(),
+		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+	}
+	err := sendGridNotificationInput.Send(context.Background(), notificationData)
 	if err != nil {
 		t.Errorf("expected nil, received error %v", err)
 	}


### PR DESCRIPTION
#### Summary
Make the Notifications system more flexible, so that it can be used for both ct-monitor and rekor-monitor and prepare for reporting not only matched identities, but also other kind of data (e.g. failed entries).