### PR TITLE
Report failed entries

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -108,7 +108,7 @@ func main() {
 			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
 			return &checkpointEndIndex
 		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			return ct.IdentitySearch(ctx, fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 		},
 	})

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -191,7 +191,7 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 			checkpointEndIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), checkpoint)
 			return &checkpointEndIndex
 		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			return rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 		},
 	})
@@ -243,8 +243,8 @@ func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifica
 		GetEndIndexFn: func(_ cmd.LogInfo) *int {
 			return nil
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
-			return nil, nil
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+			return nil, nil, nil
 		},
 	})
 }

--- a/internal/cmd/common_test.go
+++ b/internal/cmd/common_test.go
@@ -511,7 +511,7 @@ func TestMonitorLoop_BasicExecution(t *testing.T) {
 			callCount++
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			callCount++
 
@@ -534,7 +534,7 @@ func TestMonitorLoop_BasicExecution(t *testing.T) {
 						{CertSubject: "test-subject", Index: 5, UUID: "test-uuid"},
 					},
 				},
-			}, nil
+			}, nil, nil
 		},
 	}
 
@@ -579,9 +579,9 @@ func TestMonitorLoop_ConsistencyCheckError(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			t.Error("IdentitySearchFn should not be called when consistency check fails")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 
@@ -622,10 +622,10 @@ func TestMonitorLoop_NoMonitoredValues(t *testing.T) {
 			t.Error("GetEndIndexFn should not be called when no monitored values exist")
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			t.Error("IdentitySearchFn should not be called when no monitored values exist")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 
@@ -673,10 +673,10 @@ func TestMonitorLoop_InvalidIndexRange(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			t.Error("IdentitySearchFn should not be called when start index > end index")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 
@@ -718,9 +718,9 @@ func TestMonitorLoop_OnceFlag(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
-			return []identity.MonitoredIdentity{}, nil
+			return []identity.MonitoredIdentity{}, nil, nil
 		},
 	}
 
@@ -762,9 +762,9 @@ func TestMonitorLoop_EndIndexSpecified(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
-			return []identity.MonitoredIdentity{}, nil
+			return []identity.MonitoredIdentity{}, nil, nil
 		},
 	}
 

--- a/pkg/ct/monitor_test.go
+++ b/pkg/ct/monitor_test.go
@@ -380,13 +380,16 @@ func TestMatchedIndices(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		matchedEntries, err := MatchedIndices(tc.inputEntries, tc.inputMonitoredValues)
+		matchedEntries, failedEntries, err := MatchedIndices(tc.inputEntries, tc.inputMonitoredValues)
 		if err != nil {
 			t.Errorf("error matching indices: %v", err)
 		}
 		expected := tc.expected
 		if !reflect.DeepEqual(matchedEntries, expected) {
 			t.Errorf("received %v, expected %v", matchedEntries, expected)
+		}
+		if len(failedEntries) > 0 {
+			t.Errorf("received failed entries: %v", failedEntries)
 		}
 	}
 }

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -85,6 +85,13 @@ func (e *LogEntry) String() string {
 	return strings.Join(parts, " ")
 }
 
+// FailedLogEntry holds a log entry that failed to be parsed/extracted
+type FailedLogEntry struct {
+	Index int64  `json:"index"`
+	UUID  string `json:"uuid"`
+	Error string `json:"error"`
+}
+
 // MonitoredIdentity holds an identity and associated log entries matching the identity being monitored.
 type MonitoredIdentity struct {
 	Identity             string     `json:"identity"`
@@ -107,6 +114,28 @@ type MonitoredIdentityList []MonitoredIdentity
 // ToNotificationBody implements the NotificationBodyConverter interface for MonitoredIdentityList
 func (identities MonitoredIdentityList) ToNotificationBody() ([]byte, error) {
 	return PrintMonitoredIdentities(identities)
+}
+
+// ToNotificationHeader implements the NotificationBodyConverter interface for MonitoredIdentityList
+func (identities MonitoredIdentityList) ToNotificationHeader() string {
+	return "Found the following pairs of monitored identities and matching log entries: "
+}
+
+// FailedLogEntryList wraps []FailedLogEntry to implement NotificationBodyConverter
+type FailedLogEntryList []FailedLogEntry
+
+// ToNotificationBody implements the NotificationBodyConverter interface for FailedLogEntryList
+func (failedEntries FailedLogEntryList) ToNotificationBody() ([]byte, error) {
+	jsonBody, err := json.MarshalIndent(failedEntries, "", "\t")
+	if err != nil {
+		return nil, err
+	}
+	return jsonBody, nil
+}
+
+// ToNotificationHeader implements the NotificationBodyConverter interface for FailedLogEntryList
+func (failedEntries FailedLogEntryList) ToNotificationHeader() string {
+	return "Failed to parse the following log entries: "
 }
 
 // CreateIdentitiesList takes in a MonitoredValues input and returns a list of all currently monitored identities.

--- a/pkg/notifications/email.go
+++ b/pkg/notifications/email.go
@@ -16,6 +16,7 @@ package notifications
 
 import (
 	"context"
+	"strings"
 
 	"github.com/wneessen/go-mail"
 )
@@ -33,11 +34,12 @@ type EmailNotificationInput struct {
 
 // generateEmailBody generates email body for generic notification data
 func generateEmailBody(data NotificationData) (string, error) {
+	header := data.Payload.ToNotificationHeader()
 	body, err := data.Payload.ToNotificationBody()
 	if err != nil {
 		return "", err
 	}
-	return "<pre>" + string(body) + "</pre>", nil
+	return strings.Join([]string{header, "<pre>" + string(body) + "</pre>"}, "\n"), nil
 }
 
 // Send implements the NotificationPlatform interface

--- a/pkg/notifications/github_issues.go
+++ b/pkg/notifications/github_issues.go
@@ -16,14 +16,9 @@ package notifications
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/google/go-github/v65/github"
-)
-
-var (
-	notificationPlatformGitHubIssueBodyHeaderText = "%s found the following pairs of monitored identities and matching log entries: "
 )
 
 // GitHubIssueInput extends the NotificationPlatform interface to support found identity
@@ -42,8 +37,7 @@ type GitHubIssueInput struct {
 
 // generateGitHubIssueBody generates a GitHub issue body for generic notification data
 func generateGitHubIssueBody(data NotificationData) (string, error) {
-	header := fmt.Sprintf(notificationPlatformGitHubIssueBodyHeaderText, data.Context.MonitorType)
-
+	header := data.Payload.ToNotificationHeader()
 	body, err := data.Payload.ToNotificationBody()
 	if err != nil {
 		return "", err

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -40,6 +40,7 @@ type NotificationContext struct {
 // NotificationBodyConverter defines an interface for payloads that can convert themselves to a notification body string
 type NotificationBodyConverter interface {
 	ToNotificationBody() ([]byte, error)
+	ToNotificationHeader() string
 }
 
 // NotificationData represents the data to be sent in a notification

--- a/pkg/rekor/v1/identity_test.go
+++ b/pkg/rekor/v1/identity_test.go
@@ -94,7 +94,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
@@ -105,6 +105,9 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].CertSubject != subject {
 		t.Fatalf("mismatched subjects: %s %s", matches[0].CertSubject, subject)
@@ -120,7 +123,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// match to subject and issuer with certificate in hashedrekord
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
@@ -133,9 +136,12 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
 	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
+	}
 
 	// match with regex subject and regex issuer with certificate in hashedrekord
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: ".*ubje.*",
@@ -147,6 +153,9 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 
 	// match to regex subject and issuer with certificate in rekord
@@ -179,7 +188,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		}
 		logEntry := models.LogEntry{uuid: logEntryAnon}
 
-		matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 			CertificateIdentities: []identity.CertificateIdentity{
 				{
 					CertSubject: ".*ubje.*",
@@ -191,6 +200,9 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		}
 		if len(matches) != 1 {
 			t.Fatalf("expected 1 match, got %d", len(matches))
+		}
+		if len(failedEntries) != 0 {
+			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 		}
 	}
 
@@ -212,12 +224,15 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		},
 	}
 	for _, monitoredValues := range testedMonitoredValues {
-		matches, err := MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
+		matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
 		if err != nil {
 			t.Fatalf("expected error matching IDs, got %v", err)
 		}
 		if len(matches) != 0 {
 			t.Fatalf("expected 0 matches, got %d", len(matches))
+		}
+		if len(failedEntries) != 0 {
+			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 		}
 	}
 }
@@ -270,7 +285,7 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		CertificateIdentities: []identity.CertificateIdentity{
 			{
 				CertSubject: subject,
@@ -282,6 +297,9 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].CertSubject != subject {
 		t.Fatalf("mismatched subjects: %s %s", matches[0].CertSubject, subject)
@@ -348,7 +366,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	fp := hex.EncodeToString(digest[:])
 
 	//  match to key fingerprint in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Fingerprints: []string{
 			fp,
 		}})
@@ -357,6 +375,9 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].Fingerprint != fp {
 		t.Fatalf("mismatched fingerprints: %s %s", matches[0].Fingerprint, fp)
@@ -369,7 +390,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 
 	// no match with different fingerprints
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Fingerprints: []string{
 			"other-fp",
 		}})
@@ -378,6 +399,9 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 }
 
@@ -427,7 +451,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Subjects: []string{
 			subject,
 		}})
@@ -436,6 +460,9 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].Subject != subject {
 		t.Fatalf("mismatched subjects: %s %s", matches[0].Subject, subject)
@@ -448,7 +475,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 
 	// no match with different subjects
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		Subjects: []string{
 			"other-sub",
 		}})
@@ -457,6 +484,9 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected 0 matches, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 }
 
@@ -518,7 +548,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		OIDMatchers: []extensions.OIDExtension{
 			{
 				ObjectIdentifier: oid,
@@ -530,6 +560,9 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].Index != int64(logIndex) {
 		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
@@ -557,12 +590,15 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 		},
 	}
 	for _, monitoredValues := range testedMonitoredValues {
-		matches, err = MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
+		matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, monitoredValues)
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
 		if len(matches) != 0 {
 			t.Fatalf("expected no matches, got %d", len(matches))
+		}
+		if len(failedEntries) != 0 {
+			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 		}
 	}
 }
@@ -634,7 +670,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		OIDMatchers: renderedOIDMatchers,
 	})
 	if err != nil {
@@ -642,6 +678,9 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].Index != int64(logIndex) {
 		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
@@ -660,7 +699,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		OIDMatchers: renderedOIDMatchers,
 	})
 	if err != nil {
@@ -668,6 +707,9 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected no matches, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 }
 
@@ -741,13 +783,16 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
-	matches, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		OIDMatchers: renderedOIDMatchers})
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 	if matches[0].Index != int64(logIndex) {
 		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
@@ -772,7 +817,7 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
-	matches, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
 		OIDMatchers: renderedOIDMatchers})
 
 	if err != nil {
@@ -780,6 +825,9 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	}
 	if len(matches) != 0 {
 		t.Fatalf("expected no matches, got %d", len(matches))
+	}
+	if len(failedEntries) != 0 {
+		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
 }
 
@@ -851,7 +899,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 
 	for name, testCase := range monitoredValuesTests {
 		t.Run(name, func(t *testing.T) {
-			_, err := MatchedIndices(nil, testCase.input)
+			_, _, err := MatchedIndices(nil, testCase.input)
 			if err == nil || !strings.Contains(err.Error(), testCase.errorString) {
 				t.Fatalf("expected error %v, received %v", testCase.errorString, err)
 			}

--- a/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
+++ b/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
@@ -254,7 +254,7 @@ func TestIdentitySearch(t *testing.T) {
 		t.Errorf("expected previous checkpoint size of 1, received size %d", prevCheckpoint.Size)
 	}
 
-	_, err = rekor_v1.IdentitySearch(context.Background(), 0, 1, rekorClient, monitoredVals, tempOutputIdentitiesFileName, nil)
+	_, _, err = rekor_v1.IdentitySearch(context.Background(), 0, 1, rekorClient, monitoredVals, tempOutputIdentitiesFileName, nil)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
#### Summary
Fixes https://github.com/sigstore/rekor-monitor/issues/271 by collecting log entries that fail to be matched against the monitored identities. These entries are sent as notifications, similar to successful matches.

#### Release Note
* Add notifications for ct-monitor/rekor-monitor for failed log entries

---

Based on #736 