### PR TITLE
cmd: fix WriteCheckpointFn when no previous checkpoint

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -100,11 +100,11 @@ func main() {
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			var prevCheckpoint *ctgo.SignedTreeHead
-			if prev != nil {
-				var ok bool
-				prevCheckpoint, ok = prev.(*ctgo.SignedTreeHead)
-				if !ok {
+			prevCheckpoint, ok := prev.(*ctgo.SignedTreeHead)
+			if !ok {
+				if prev == nil {
+					prevCheckpoint = nil
+				} else {
 					return fmt.Errorf("prev is not a SignedTreeHead")
 				}
 			}

--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -101,12 +101,8 @@ func main() {
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
 			prevCheckpoint, ok := prev.(*ctgo.SignedTreeHead)
-			if !ok {
-				if prev == nil {
-					prevCheckpoint = nil
-				} else {
-					return fmt.Errorf("prev is not a SignedTreeHead")
-				}
+			if !ok && prev != nil {
+				return fmt.Errorf("prev is not a SignedTreeHead")
 			}
 			curCheckpoint, ok := cur.(*ctgo.SignedTreeHead)
 			if !ok {

--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -100,9 +100,13 @@ func main() {
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*ctgo.SignedTreeHead)
-			if !ok {
-				return fmt.Errorf("prev is not a SignedTreeHead")
+			var prevCheckpoint *ctgo.SignedTreeHead
+			if prev != nil {
+				var ok bool
+				prevCheckpoint, ok = prev.(*ctgo.SignedTreeHead)
+				if !ok {
+					return fmt.Errorf("prev is not a SignedTreeHead")
+				}
 			}
 			curCheckpoint, ok := cur.(*ctgo.SignedTreeHead)
 			if !ok {

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -182,11 +182,11 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			var prevCheckpoint *util.SignedCheckpoint
-			if prev != nil {
-				var ok bool
-				prevCheckpoint, ok = prev.(*util.SignedCheckpoint)
-				if !ok {
+			prevCheckpoint, ok := prev.(*util.SignedCheckpoint)
+			if !ok {
+				if prev == nil {
+					prevCheckpoint = nil
+				} else {
 					return fmt.Errorf("prev is not a SignedCheckpoint")
 				}
 			}
@@ -266,11 +266,11 @@ func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifica
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			var prevCheckpoint *tlog.Checkpoint
-			if prev != nil {
-				var ok bool
-				prevCheckpoint, ok = prev.(*tlog.Checkpoint)
-				if !ok {
+			prevCheckpoint, ok := prev.(*tlog.Checkpoint)
+			if !ok {
+				if prev == nil {
+					prevCheckpoint = nil
+				} else {
 					return fmt.Errorf("prev is not a Checkpoint")
 				}
 			}

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -183,12 +183,8 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
 			prevCheckpoint, ok := prev.(*util.SignedCheckpoint)
-			if !ok {
-				if prev == nil {
-					prevCheckpoint = nil
-				} else {
-					return fmt.Errorf("prev is not a SignedCheckpoint")
-				}
+			if !ok && prev != nil {
+				return fmt.Errorf("prev is not a SignedCheckpoint")
 			}
 			curCheckpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
 			if err != nil {
@@ -266,12 +262,8 @@ func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifica
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
 			prevCheckpoint, ok := prev.(*tlog.Checkpoint)
-			if !ok {
-				if prev == nil {
-					prevCheckpoint = nil
-				} else {
-					return fmt.Errorf("prev is not a Checkpoint")
-				}
+			if !ok && prev != nil {
+				return fmt.Errorf("prev is not a Checkpoint")
 			}
 			curCheckpoint, ok := cur.(*tlog.Checkpoint)
 			if !ok {

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -182,10 +182,15 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*util.SignedCheckpoint)
-			if !ok {
-				return fmt.Errorf("prev is not a SignedCheckpoint")
+			var prevCheckpoint *util.SignedCheckpoint
+			if prev != nil {
+				var ok bool
+				prevCheckpoint, ok = prev.(*util.SignedCheckpoint)
+				if !ok {
+					return fmt.Errorf("prev is not a SignedCheckpoint")
+				}
 			}
+
 			curCheckpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
 			if err != nil {
 				return fmt.Errorf("failed to read latest checkpoint: %v", err)
@@ -261,9 +266,13 @@ func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifica
 			return prevCheckpoint, curLogInfo, nil
 		},
 		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*tlog.Checkpoint)
-			if !ok {
-				return fmt.Errorf("prev is not a Checkpoint")
+			var prevCheckpoint *tlog.Checkpoint
+			if prev != nil {
+				var ok bool
+				prevCheckpoint, ok = prev.(*tlog.Checkpoint)
+				if !ok {
+					return fmt.Errorf("prev is not a Checkpoint")
+				}
 			}
 			curCheckpoint, ok := cur.(*tlog.Checkpoint)
 			if !ok {

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -190,7 +190,6 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 					return fmt.Errorf("prev is not a SignedCheckpoint")
 				}
 			}
-
 			curCheckpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
 			if err != nil {
 				return fmt.Errorf("failed to read latest checkpoint: %v", err)


### PR DESCRIPTION
#### Summary
Fix issue when writing the first checkpoint, with a `prev == nil`.