### PR TITLE
Fix regex map when creating matching identities

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -123,7 +123,7 @@ func main() {
 			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
 			return &checkpointEndIndex
 		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			return ct.IdentitySearch(ctx, fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 		},
 	})

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -211,7 +211,7 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 			checkpointEndIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), checkpoint)
 			return &checkpointEndIndex
 		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			return rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 		},
 	})
@@ -280,8 +280,8 @@ func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifica
 		GetEndIndexFn: func(_ cmd.LogInfo) *int {
 			return nil
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
-			return nil, nil, nil
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
+			return identity.MatchedEntries{}, nil, nil
 		},
 	})
 }

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -56,7 +56,7 @@ type MonitorLoopParams struct {
 	WriteCheckpointFn        func(prev Checkpoint, cur LogInfo) error
 	GetStartIndexFn          func(prev Checkpoint, cur LogInfo) *int
 	GetEndIndexFn            func(cur LogInfo) *int
-	IdentitySearchFn         func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error)
+	IdentitySearchFn         func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error)
 }
 
 type Checkpoint interface{}
@@ -205,13 +205,13 @@ func MonitorLoop(params MonitorLoopParams) {
 					return
 				}
 
-				if len(foundEntries) > 0 || len(failedEntries) > 0 {
+				if foundEntries.Len() > 0 || len(failedEntries) > 0 {
 					notificationPool := notifications.CreateNotificationPool(*config)
 
-					if len(foundEntries) > 0 {
+					if foundEntries.Len() > 0 {
 						notificationData := notifications.NotificationData{
 							Context: params.NotificationContextNewFn(),
-							Payload: identity.MonitoredIdentityList(foundEntries),
+							Payload: identity.MatchedEntries(foundEntries),
 						}
 
 						err = notifications.TriggerNotifications(notificationPool, notificationData)

--- a/internal/cmd/common_test.go
+++ b/internal/cmd/common_test.go
@@ -515,7 +515,7 @@ func TestMonitorLoop_BasicExecution(t *testing.T) {
 			callCount++
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			callCount++
 
@@ -531,14 +531,9 @@ func TestMonitorLoop_BasicExecution(t *testing.T) {
 			}
 
 			// Return some found identities to trigger notifications
-			return []identity.MonitoredIdentity{
-				{
-					Identity: "test-identity",
-					FoundIdentityEntries: []identity.LogEntry{
-						{CertSubject: "test-subject", Index: 5, UUID: "test-uuid"},
-					},
-				},
-			}, nil, nil
+			return identity.NewMatchedEntries(
+				identity.LogEntry{CertSubject: "test-subject", Index: 5, UUID: "test-uuid"},
+			), nil, nil
 		},
 	}
 
@@ -583,9 +578,9 @@ func TestMonitorLoop_ConsistencyCheckError(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			t.Error("IdentitySearchFn should not be called when consistency check fails")
-			return nil, nil, nil
+			return identity.MatchedEntries{}, nil, nil
 		},
 	}
 
@@ -631,10 +626,10 @@ func TestMonitorLoop_NoMonitoredValues(t *testing.T) {
 			t.Error("GetEndIndexFn should not be called when no monitored values exist")
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			t.Error("IdentitySearchFn should not be called when no monitored values exist")
-			return nil, nil, nil
+			return identity.MatchedEntries{}, nil, nil
 		},
 	}
 
@@ -685,10 +680,10 @@ func TestMonitorLoop_InvalidIndexRange(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return nil
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
 			t.Error("IdentitySearchFn should not be called when start index > end index")
-			return nil, nil, nil
+			return identity.MatchedEntries{}, nil, nil
 		},
 	}
 
@@ -735,9 +730,9 @@ func TestMonitorLoop_OnceFlag(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
-			return []identity.MonitoredIdentity{}, nil, nil
+			return identity.MatchedEntries{}, nil, nil
 		},
 	}
 
@@ -787,9 +782,9 @@ func TestMonitorLoop_EndIndexSpecified(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled = true
-			return []identity.MonitoredIdentity{}, nil, nil
+			return identity.MatchedEntries{}, nil, nil
 		},
 	}
 
@@ -843,12 +838,12 @@ func TestMonitorLoop_NoPreviousCheckpoint(t *testing.T) {
 		GetEndIndexFn: func(_ LogInfo) *int {
 			return intPtr(10)
 		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) (identity.MatchedEntries, []identity.FailedLogEntry, error) {
 			identitySearchCalled++
 			if identitySearchCalled == 3 {
-				return []identity.MonitoredIdentity{}, []identity.FailedLogEntry{}, fmt.Errorf("stop the loop")
+				return identity.MatchedEntries{}, []identity.FailedLogEntry{}, fmt.Errorf("stop the loop")
 			}
-			return []identity.MonitoredIdentity{}, []identity.FailedLogEntry{}, nil
+			return identity.MatchedEntries{}, []identity.FailedLogEntry{}, nil
 		},
 	}
 

--- a/pkg/fulcio/extensions/extensions.go
+++ b/pkg/fulcio/extensions/extensions.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -177,6 +178,18 @@ type FulcioExtensions struct {
 type OIDExtension struct {
 	ObjectIdentifier asn1.ObjectIdentifier `yaml:"objectIdentifier"`
 	ExtensionValues  []string              `yaml:"extensionValues"`
+}
+
+func (e OIDExtension) String() string {
+	// Create a more readable representation for the map key
+	if len(e.ExtensionValues) == 0 {
+		return fmt.Sprintf("objId:%s", e.ObjectIdentifier.String())
+	}
+	// Sort the extension values to ensure consistent hashing regardless of order
+	extensionValues := make([]string, len(e.ExtensionValues))
+	copy(extensionValues, e.ExtensionValues)
+	sort.Strings(extensionValues)
+	return fmt.Sprintf("objId:%s:extValues:%v", e.ObjectIdentifier.String(), extensionValues)
 }
 
 // CustomExtension holds an OID field represented in dot notation and a list of values to match on

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 
@@ -43,186 +42,34 @@ func TestIdentityEntryString(t *testing.T) {
 	}
 }
 
-// Test CreateMonitoredIdentities
-func TestCreateMonitoredIdentities(t *testing.T) {
-	type test struct {
-		inputEntries    []LogEntry
-		inputIdentities []string
-		output          []MonitoredIdentity
-	}
-
-	testIdentities := map[string]string{
-		"testCertSubject":    "test-cert-subject",
-		"testFingerprint":    "test-fingerprint",
-		"testExtensionValue": "test-extension-value",
-		"testSubject":        "test-subject",
-	}
-
-	testUUIDs := map[string]string{
-		"testUUID":  "test-uuid",
-		"testUUID2": "test-uuid-2",
-	}
-
-	testIndexes := map[string]int64{
-		"1": int64(1),
-		"2": int64(2),
-	}
-
-	testIdentityEntries := map[string]LogEntry{
-		"testCertSubject1": {
-			CertSubject: testIdentities["testCertSubject"],
-			UUID:        testUUIDs["testUUID"],
-			Index:       testIndexes["1"],
+// Test PrintMatchedEntries
+func TestPrintMatchedEntries(t *testing.T) {
+	matchedEntries := NewMatchedEntries(
+		LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-		"testCertSubject2": {
-			CertSubject: testIdentities["testCertSubject"],
-			UUID:        testUUIDs["testUUID2"],
-			Index:       testIndexes["2"],
-		},
-		"testFingerprint1": {
-			Fingerprint: testIdentities["testFingerprint"],
-			UUID:        testUUIDs["testUUID"],
-			Index:       testIndexes["1"],
-		},
-		"testFingerprint2": {
-			Fingerprint: testIdentities["testFingerprint"],
-			UUID:        testUUIDs["testUUID"],
-			Index:       testIndexes["2"],
-		},
-		"testExtensionValue1": {
-			ExtensionValue: testIdentities["testExtensionValue"],
-			UUID:           testUUIDs["testUUID"],
-			Index:          testIndexes["1"],
-		},
-		"testExtensionValue2": {
-			ExtensionValue: testIdentities["testExtensionValue"],
-			UUID:           testUUIDs["testUUID"],
-			Index:          testIndexes["2"],
-		},
-		"testSubject1": {
-			Subject: testIdentities["testSubject"],
-			UUID:    testUUIDs["testUUID"],
-			Index:   testIndexes["1"],
-		},
-		"testSubject2": {
-			Subject: testIdentities["testSubject"],
-			UUID:    testUUIDs["testUUID"],
-			Index:   testIndexes["2"],
-		},
-	}
-
-	testMonitoredIdentities := map[string]MonitoredIdentity{
-		"testMonitoredIdCertSubject1": {
-			Identity:             testIdentities["testCertSubject"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testCertSubject1"]},
-		},
-		"testMonitoredIdCertSubject2": {
-			Identity:             testIdentities["testCertSubject"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testCertSubject1"], testIdentityEntries["testCertSubject2"]},
-		},
-		"testMonitoredIdFingerprint1": {
-			Identity:             testIdentities["testFingerprint"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testFingerprint1"]},
-		},
-		"testMonitoredIdFingerprint2": {
-			Identity:             testIdentities["testFingerprint"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testFingerprint1"], testIdentityEntries["testFingerprint2"]},
-		},
-		"testMonitoredIdExtensionValue1": {
-			Identity:             testIdentities["testExtensionValue"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testExtensionValue1"]},
-		},
-		"testMonitoredIdExtensionValue2": {
-			Identity:             testIdentities["testExtensionValue"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testExtensionValue1"], testIdentityEntries["testExtensionValue2"]},
-		},
-		"testMonitoredIdSubject1": {
-			Identity:             testIdentities["testSubject"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testSubject1"]},
-		},
-		"testMonitoredIdSubject2": {
-			Identity:             testIdentities["testSubject"],
-			FoundIdentityEntries: []LogEntry{testIdentityEntries["testSubject1"], testIdentityEntries["testSubject2"]},
-		},
-	}
-
-	tests := map[string]test{
-		"empty case": {
-			inputEntries:    []LogEntry{},
-			inputIdentities: []string{},
-			output:          []MonitoredIdentity{},
-		},
-		"one entry for given identity": {
-			inputEntries:    []LogEntry{testIdentityEntries["testCertSubject1"]},
-			inputIdentities: []string{testIdentities["testCertSubject"]},
-			output:          []MonitoredIdentity{testMonitoredIdentities["testMonitoredIdCertSubject1"]},
-		},
-		"multiple log entries under same identity": {
-			inputEntries:    []LogEntry{testIdentityEntries["testCertSubject1"], testIdentityEntries["testCertSubject2"]},
-			inputIdentities: []string{testIdentities["testCertSubject"]},
-			output:          []MonitoredIdentity{testMonitoredIdentities["testMonitoredIdCertSubject2"]},
-		},
-		"no log entries matching given identity": {
-			inputEntries:    []LogEntry{testIdentityEntries["testCertSubject1"], testIdentityEntries["testCertSubject2"]},
-			inputIdentities: []string{testIdentities["testFingerprint"]},
-			output:          []MonitoredIdentity{},
-		},
-		"test all identities": {
-			inputEntries:    []LogEntry{testIdentityEntries["testCertSubject1"], testIdentityEntries["testFingerprint1"], testIdentityEntries["testExtensionValue1"], testIdentityEntries["testSubject1"], testIdentityEntries["testCertSubject2"], testIdentityEntries["testFingerprint2"], testIdentityEntries["testExtensionValue2"], testIdentityEntries["testSubject2"]},
-			inputIdentities: []string{testIdentities["testCertSubject"], testIdentities["testFingerprint"], testIdentities["testExtensionValue"], testIdentities["testSubject"]},
-			output:          []MonitoredIdentity{testMonitoredIdentities["testMonitoredIdCertSubject2"], testMonitoredIdentities["testMonitoredIdExtensionValue2"], testMonitoredIdentities["testMonitoredIdFingerprint2"], testMonitoredIdentities["testMonitoredIdSubject2"]},
-		},
-	}
-
-	for name, testCase := range tests {
-		t.Run(name, func(t *testing.T) {
-			createMonitoredIdentitiesOutput := CreateMonitoredIdentities(testCase.inputEntries, testCase.inputIdentities)
-			sort.Slice(createMonitoredIdentitiesOutput, func(i, j int) bool {
-				return createMonitoredIdentitiesOutput[i].Identity < createMonitoredIdentitiesOutput[j].Identity
-			})
-			if !reflect.DeepEqual(createMonitoredIdentitiesOutput, testCase.output) {
-				t.Errorf("expected %v, got %v", testCase.output, createMonitoredIdentitiesOutput)
-			}
-		})
-	}
-}
-
-// Test PrintMonitoredIdentities
-func TestPrintMonitoredIdentities(t *testing.T) {
-	monitoredIdentity := MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
-		},
-	}
-	parsedMonitoredIdentity, err := PrintMonitoredIdentities([]MonitoredIdentity{monitoredIdentity})
+	)
+	parsedMatchedEntries, err := matchedEntries.ToNotificationBody()
 	if err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
-	expectedParsedMonitoredIdentityOutput := strings.Fields(`[
-        	{
-        		"identity": "test-identity",
-        		"foundIdentityEntries": [
-        			{
-        				"CertSubject": "test-cert-subject",
-        				"Issuer": "",
-        				"Fingerprint": "",
-        				"Subject": "",
-        				"Index": 0,
-        				"UUID": "test-uuid",
-        				"OIDExtension": null,
-        				"ExtensionValue": ""
-        			}
-        		]
-        	}
+	expectedParsedMatchedEntriesOutput := strings.Fields(`[
+			{
+				"CertSubject": "test-cert-subject",
+				"Issuer": "",
+				"Fingerprint": "",
+				"Subject": "",
+				"Index": 0,
+				"UUID": "test-uuid",
+				"OIDExtension": null,
+				"ExtensionValue": ""
+			}
         ]`)
-	parsedMonitoredIdentityFields := strings.Fields(string(parsedMonitoredIdentity))
-	if !reflect.DeepEqual(parsedMonitoredIdentityFields, expectedParsedMonitoredIdentityOutput) {
-		t.Errorf("expected parsed monitored identity to equal %s, got %s", expectedParsedMonitoredIdentityOutput, parsedMonitoredIdentityFields)
+	parsedMatchedEntriesFields := strings.Fields(string(parsedMatchedEntries))
+	if !reflect.DeepEqual(parsedMatchedEntriesFields, expectedParsedMatchedEntriesOutput) {
+		t.Errorf("expected parsed monitored identity to equal %s, got %s", expectedParsedMatchedEntriesOutput, parsedMatchedEntriesFields)
 	}
 }
 

--- a/pkg/notifications/email_test.go
+++ b/pkg/notifications/email_test.go
@@ -55,21 +55,18 @@ func TestEmailSendFailureCases(t *testing.T) {
 			SMTPHostURL:           "smtp.mail.com",
 		},
 	}
-	monitoredIdentity := identity.MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []identity.LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
+	monitoredIdentity := identity.NewMatchedEntries(
+		identity.LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-	}
+	)
 
 	for _, emailNotificationInput := range emailNotificationInputs {
 		notificationData := NotificationData{
 			Context: CreateNotificationContext("test-monitor", "test-subject"),
-			Payload: identity.MonitoredIdentityList{monitoredIdentity},
+			Payload: monitoredIdentity,
 		}
 		err := emailNotificationInput.Send(context.Background(), notificationData)
 		if err == nil {
@@ -85,16 +82,13 @@ func TestEmailSendMockSMTPServerSuccess(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Errorf("error starting server: %v", err)
 	}
-	monitoredIdentity := identity.MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []identity.LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
+	monitoredIdentity := identity.NewMatchedEntries(
+		identity.LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-	}
+	)
 	emailNotificationInput := EmailNotificationInput{
 		RecipientEmailAddress: "test-recipient@mail.com",
 		SenderEmailAddress:    "example-sender@mail.com",
@@ -104,7 +98,7 @@ func TestEmailSendMockSMTPServerSuccess(t *testing.T) {
 
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+		Payload: monitoredIdentity,
 	}
 	err := emailNotificationInput.Send(context.Background(), notificationData)
 	if err != nil {
@@ -120,16 +114,13 @@ func TestEmailSendMockSMTPServerFailure(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Errorf("error starting server: %v", err)
 	}
-	monitoredIdentity := identity.MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []identity.LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
+	monitoredIdentity := identity.NewMatchedEntries(
+		identity.LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-	}
+	)
 	emailNotificationInput := EmailNotificationInput{
 		RecipientEmailAddress: "test-recipient@mail.com",
 		SenderEmailAddress:    "example-sender@mail.com",
@@ -139,7 +130,7 @@ func TestEmailSendMockSMTPServerFailure(t *testing.T) {
 
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+		Payload: monitoredIdentity,
 	}
 	err := emailNotificationInput.Send(context.Background(), notificationData)
 	if err == nil || !strings.Contains(err.Error(), "421 Service not available") {

--- a/pkg/notifications/github_issues_test.go
+++ b/pkg/notifications/github_issues_test.go
@@ -36,7 +36,7 @@ func TestGitHubIssueInputSend401BadCredentialsFailure(t *testing.T) {
 	ctx := context.Background()
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{},
+		Payload: identity.MatchedEntries{},
 	}
 	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err == nil {
@@ -73,7 +73,7 @@ func TestGitHubIssueInputMockSendSuccess(t *testing.T) {
 	ctx := context.Background()
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{},
+		Payload: identity.MatchedEntries{},
 	}
 	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err != nil {
@@ -105,7 +105,7 @@ func TestGitHubIssueInputMockSendFailure(t *testing.T) {
 	ctx := context.Background()
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{},
+		Payload: identity.MatchedEntries{},
 	}
 	err := gitHubIssuesInput.Send(ctx, notificationData)
 	if err == nil || !strings.Contains(err.Error(), "400 Bad Request") {

--- a/pkg/notifications/mailgun_test.go
+++ b/pkg/notifications/mailgun_test.go
@@ -28,20 +28,17 @@ func TestMailgunSendFailure(t *testing.T) {
 		MailgunAPIKey:         "",
 		MailgunDomainName:     "",
 	}
-	monitoredIdentity := identity.MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []identity.LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
+	monitoredIdentity := identity.NewMatchedEntries(
+		identity.LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-	}
+	)
 
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+		Payload: monitoredIdentity,
 	}
 	err := mailgunNotificationInput.Send(context.Background(), notificationData)
 	if err == nil {

--- a/pkg/notifications/notifications_test.go
+++ b/pkg/notifications/notifications_test.go
@@ -54,7 +54,7 @@ func TestCreateAndSendNotifications(t *testing.T) {
 
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{},
+		Payload: identity.MatchedEntries{},
 	}
 
 	err := TriggerNotifications([]NotificationPlatform{mockNotificationPlatform}, notificationData)

--- a/pkg/notifications/sendgrid_test.go
+++ b/pkg/notifications/sendgrid_test.go
@@ -29,20 +29,17 @@ func TestSendGridSendFailure(t *testing.T) {
 		SenderName:            "",
 		SendGridAPIKey:        "",
 	}
-	monitoredIdentity := identity.MonitoredIdentity{
-		Identity: "test-identity",
-		FoundIdentityEntries: []identity.LogEntry{
-			{
-				CertSubject: "test-cert-subject",
-				UUID:        "test-uuid",
-				Index:       0,
-			},
+	monitoredIdentity := identity.NewMatchedEntries(
+		identity.LogEntry{
+			CertSubject: "test-cert-subject",
+			UUID:        "test-uuid",
+			Index:       0,
 		},
-	}
+	)
 
 	notificationData := NotificationData{
 		Context: CreateNotificationContext("test-monitor", "test-subject"),
-		Payload: identity.MonitoredIdentityList{monitoredIdentity},
+		Payload: monitoredIdentity,
 	}
 	err := sendGridNotificationInput.Send(context.Background(), notificationData)
 	if err != nil {

--- a/pkg/rekor/v1/identity_test.go
+++ b/pkg/rekor/v1/identity_test.go
@@ -103,23 +103,23 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].CertSubject != subject {
-		t.Fatalf("mismatched subjects: %s %s", matches[0].CertSubject, subject)
+	if matches.Entries[uuid].CertSubject != subject {
+		t.Fatalf("mismatched subjects: %s %s", matches.Entries[uuid].CertSubject, subject)
 	}
-	if matches[0].Issuer != issuer {
-		t.Fatalf("mismatched issuers: %s %s", matches[0].Issuer, issuer)
+	if matches.Entries[uuid].Issuer != issuer {
+		t.Fatalf("mismatched issuers: %s %s", matches.Entries[uuid].Issuer, issuer)
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	// match to subject and issuer with certificate in hashedrekord
@@ -133,8 +133,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -151,8 +151,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -198,8 +198,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected error matching IDs, got %v", err)
 		}
-		if len(matches) != 1 {
-			t.Fatalf("expected 1 match, got %d", len(matches))
+		if matches.Len() != 1 {
+			t.Fatalf("expected 1 match, got %d", matches.Len())
 		}
 		if len(failedEntries) != 0 {
 			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -228,8 +228,8 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected error matching IDs, got %v", err)
 		}
-		if len(matches) != 0 {
-			t.Fatalf("expected 0 matches, got %d", len(matches))
+		if matches.Len() != 0 {
+			t.Fatalf("expected 0 matches, got %d", matches.Len())
 		}
 		if len(failedEntries) != 0 {
 			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -295,17 +295,17 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].CertSubject != subject {
-		t.Fatalf("mismatched subjects: %s %s", matches[0].CertSubject, subject)
+	if matches.Entries[uuid].CertSubject != subject {
+		t.Fatalf("mismatched subjects: %s %s", matches.Entries[uuid].CertSubject, subject)
 	}
-	if matches[0].Issuer != issuer {
-		t.Fatalf("mismatched issuers: %s %s", matches[0].Issuer, issuer)
+	if matches.Entries[uuid].Issuer != issuer {
+		t.Fatalf("mismatched issuers: %s %s", matches.Entries[uuid].Issuer, issuer)
 	}
 }
 
@@ -373,20 +373,20 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].Fingerprint != fp {
-		t.Fatalf("mismatched fingerprints: %s %s", matches[0].Fingerprint, fp)
+	if matches.Entries[uuid].Fingerprint != fp {
+		t.Fatalf("mismatched fingerprints: %s %s", matches.Entries[uuid].Fingerprint, fp)
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	// no match with different fingerprints
@@ -397,8 +397,8 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching fingerprints, got %v", err)
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected 0 matches, got %d", len(matches))
+	if matches.Len() != 0 {
+		t.Fatalf("expected 0 matches, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -458,20 +458,20 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].Subject != subject {
-		t.Fatalf("mismatched subjects: %s %s", matches[0].Subject, subject)
+	if matches.Entries[uuid].Subject != subject {
+		t.Fatalf("mismatched subjects: %s %s", matches.Entries[uuid].Subject, subject)
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	// no match with different subjects
@@ -482,8 +482,8 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching subjects, got %v", err)
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected 0 matches, got %d", len(matches))
+	if matches.Len() != 0 {
+		t.Fatalf("expected 0 matches, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -558,17 +558,17 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	testedMonitoredValues := []identity.MonitoredValues{
@@ -594,8 +594,8 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if len(matches) != 0 {
-			t.Fatalf("expected no matches, got %d", len(matches))
+		if matches.Len() != 0 {
+			t.Fatalf("expected no matches, got %d", matches.Len())
 		}
 		if len(failedEntries) != 0 {
 			t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -676,17 +676,17 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	// no match to oid with different oid extension field
@@ -705,8 +705,8 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
+	if matches.Len() != 0 {
+		t.Fatalf("expected no matches, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
@@ -788,17 +788,17 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
-	if len(matches) != 1 {
-		t.Fatalf("expected 1 match, got %d", len(matches))
+	if matches.Len() != 1 {
+		t.Fatalf("expected 1 match, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))
 	}
-	if matches[0].Index != int64(logIndex) {
-		t.Fatalf("mismatched log indices: %d %d", matches[0].Index, logIndex)
+	if matches.Entries[uuid].Index != int64(logIndex) {
+		t.Fatalf("mismatched log indices: %d %d", matches.Entries[uuid].Index, logIndex)
 	}
-	if matches[0].UUID != uuid {
-		t.Fatalf("mismatched UUIDs: %s %s", matches[0].UUID, uuid)
+	if matches.Entries[uuid].UUID != uuid {
+		t.Fatalf("mismatched UUIDs: %s %s", matches.Entries[uuid].UUID, uuid)
 	}
 
 	oidMatchers = extensions.OIDMatchers{
@@ -823,8 +823,8 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if len(matches) != 0 {
-		t.Fatalf("expected no matches, got %d", len(matches))
+	if matches.Len() != 0 {
+		t.Fatalf("expected no matches, got %d", matches.Len())
 	}
 	if len(failedEntries) != 0 {
 		t.Fatalf("expected 0 failed entries, got %d", len(failedEntries))

--- a/pkg/util/file/file.go
+++ b/pkg/util/file/file.go
@@ -252,12 +252,12 @@ func ReadIdentityMetadata(metadataFile string) (*IdentityMetadata, error) {
 }
 
 // WriteMatchedIdentityEntries writes a list of matched identities to a file
-func WriteMatchedIdentityEntries(identitiesFile string, matchedEntries []identity.LogEntry, idMetadataFile *string, endIndex int) error {
-	if len(matchedEntries) > 0 {
-		for _, idEntry := range matchedEntries {
-			fmt.Fprintf(os.Stderr, "Found %s\n", idEntry.String())
+func WriteMatchedIdentityEntries(identitiesFile string, matchedEntries identity.MatchedEntries, idMetadataFile *string, endIndex int) error {
+	if matchedEntries.Len() > 0 {
+		for _, entry := range matchedEntries.Entries {
+			fmt.Fprintf(os.Stderr, "Found %s\n", entry.String())
 
-			if err := WriteIdentity(identitiesFile, idEntry); err != nil {
+			if err := WriteIdentity(identitiesFile, entry); err != nil {
 				return fmt.Errorf("failed to write entry: %v", err)
 			}
 		}


### PR DESCRIPTION
#### Summary
When the monitored identities contain a regex, the identities would not be properly matched. This commit fixes the issue while also removing the "identity grouping" implemented before, which had a fuzzy definition. Entries are just output as a flat list of entries that matched one or more monitored identities.

Closes #687
