### PR TITLE
internal/cmd: Use interface instead of callbacks

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -39,12 +39,81 @@ const (
 	outputIdentitiesFileName = "ctIdentities.txt"
 )
 
-// CreateCTMonitorNotificationContext creates a notification context for ct-monitor
-func CreateCTMonitorNotificationContext() notifications.NotificationContext {
+type CTMonitorLogic struct {
+	fulcioClient    *ctclient.LogClient
+	flags           *cmd.MonitorFlags
+	config          *notifications.IdentityMonitorConfiguration
+	monitoredValues identity.MonitoredValues
+}
+
+func (l CTMonitorLogic) Interval() time.Duration {
+	return l.flags.Interval
+}
+
+func (l CTMonitorLogic) Config() *notifications.IdentityMonitorConfiguration {
+	return l.config
+}
+
+func (l CTMonitorLogic) MonitoredValues() identity.MonitoredValues {
+	return l.monitoredValues
+}
+
+func (l CTMonitorLogic) Once() bool {
+	return l.flags.Once
+}
+
+func (l CTMonitorLogic) NotificationContextNew() notifications.NotificationContext {
 	return notifications.CreateNotificationContext(
 		"ct-monitor",
 		fmt.Sprintf("ct-monitor workflow results for %s", time.Now().Format(time.RFC822)),
 	)
+}
+
+func (l CTMonitorLogic) RunConsistencyCheck(ctx context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
+	prev, cur, err := ct.RunConsistencyCheck(l.fulcioClient, l.flags.LogInfoFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	var prevCheckpoint cmd.Checkpoint
+	if prev != nil {
+		prevCheckpoint = prev
+	}
+	var curLogInfo cmd.LogInfo
+	if cur != nil {
+		curLogInfo = cur
+	}
+	return prevCheckpoint, curLogInfo, nil
+}
+
+func (l CTMonitorLogic) WriteCheckpoint(prev cmd.Checkpoint, cur cmd.LogInfo) error {
+	prevCheckpoint, ok := prev.(*ctgo.SignedTreeHead)
+	if !ok && prev != nil {
+		return fmt.Errorf("prev is not a SignedTreeHead")
+	}
+	curCheckpoint, ok := cur.(*ctgo.SignedTreeHead)
+	if !ok {
+		return fmt.Errorf("cur is not a SignedTreeHead")
+	}
+	if err := file.WriteCTSignedTreeHead(curCheckpoint, prevCheckpoint, l.flags.LogInfoFile, false); err != nil {
+		return fmt.Errorf("failed to write checkpoint: %v", err)
+	}
+	return nil
+}
+
+func (l CTMonitorLogic) GetStartIndex(prev cmd.Checkpoint, cur cmd.LogInfo) *int {
+	prevSTH := prev.(*ctgo.SignedTreeHead)
+	checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
+	return &checkpointStartIndex
+}
+
+func (l CTMonitorLogic) GetEndIndex(cur cmd.LogInfo) *int {
+	currentSTH := cur.(*ctgo.SignedTreeHead)
+	checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
+	return &checkpointEndIndex
+}
+
+func (l CTMonitorLogic) IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+	return ct.IdentitySearch(ctx, l.fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
 }
 
 // This main function performs a periodic identity search.
@@ -78,53 +147,12 @@ func main() {
 	}
 
 	cmd.PrintMonitoredValues(monitoredValues)
-	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:                 flags.Interval,
-		Config:                   config,
-		MonitoredValues:          monitoredValues,
-		Once:                     flags.Once,
-		NotificationContextNewFn: CreateCTMonitorNotificationContext,
-		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
-			prev, cur, err := ct.RunConsistencyCheck(fulcioClient, flags.LogInfoFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			var prevCheckpoint cmd.Checkpoint
-			if prev != nil {
-				prevCheckpoint = prev
-			}
-			var curLogInfo cmd.LogInfo
-			if cur != nil {
-				curLogInfo = cur
-			}
-			return prevCheckpoint, curLogInfo, nil
-		},
-		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*ctgo.SignedTreeHead)
-			if !ok && prev != nil {
-				return fmt.Errorf("prev is not a SignedTreeHead")
-			}
-			curCheckpoint, ok := cur.(*ctgo.SignedTreeHead)
-			if !ok {
-				return fmt.Errorf("cur is not a SignedTreeHead")
-			}
-			if err := file.WriteCTSignedTreeHead(curCheckpoint, prevCheckpoint, flags.LogInfoFile, false); err != nil {
-				return fmt.Errorf("failed to write checkpoint: %v", err)
-			}
-			return nil
-		},
-		GetStartIndexFn: func(prev cmd.Checkpoint, _ cmd.LogInfo) *int {
-			prevSTH := prev.(*ctgo.SignedTreeHead)
-			checkpointStartIndex := int(prevSTH.TreeSize) //nolint: gosec // G115, log will never be large enough to overflow
-			return &checkpointStartIndex
-		},
-		GetEndIndexFn: func(cur cmd.LogInfo) *int {
-			currentSTH := cur.(*ctgo.SignedTreeHead)
-			checkpointEndIndex := int(currentSTH.TreeSize) //nolint: gosec // G115
-			return &checkpointEndIndex
-		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
-			return ct.IdentitySearch(ctx, fulcioClient, *config.StartIndex, *config.EndIndex, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
-		},
-	})
+
+	ctMonitorLogic := CTMonitorLogic{
+		fulcioClient:    fulcioClient,
+		flags:           flags,
+		config:          config,
+		monitoredValues: monitoredValues,
+	}
+	cmd.MonitorLoop(ctMonitorLogic)
 }

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -29,10 +29,12 @@ import (
 	rekor_v2 "github.com/sigstore/rekor-monitor/pkg/rekor/v2"
 	"github.com/sigstore/rekor-monitor/pkg/util/file"
 	"github.com/sigstore/rekor/pkg/client"
+	rekor_client "github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/util"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
+	"github.com/sigstore/sigstore/pkg/signature"
 	tlog "github.com/transparency-dev/formats/log"
 )
 
@@ -43,14 +45,6 @@ const (
 	outputIdentitiesFileName = "identities.txt"
 	logInfoFileNamePrefix    = "logInfo"
 )
-
-// CreateRekorMonitorNotificationContext creates a notification context for rekor-monitor
-func CreateRekorMonitorNotificationContext() notifications.NotificationContext {
-	return notifications.CreateNotificationContext(
-		"rekor-monitor",
-		fmt.Sprintf("rekor-monitor workflow results for %s", time.Now().Format(time.RFC822)),
-	)
-}
 
 func getTUFClient(flags *cmd.MonitorFlags) (*tuf.Client, error) {
 	switch flags.TUFRepository {
@@ -76,6 +70,186 @@ func getTUFClient(flags *cmd.MonitorFlags) (*tuf.Client, error) {
 		options := tuf.DefaultOptions().WithRoot(rootBytes).WithRepositoryBaseURL(flags.TUFRepository)
 		return tuf.New(options)
 	}
+}
+
+type RekorV1MonitorLogic struct {
+	rekorClient     *rekor_client.Rekor
+	verifier        signature.Verifier
+	flags           *cmd.MonitorFlags
+	config          *notifications.IdentityMonitorConfiguration
+	monitoredValues identity.MonitoredValues
+}
+
+func (l RekorV1MonitorLogic) Interval() time.Duration {
+	return l.flags.Interval
+}
+
+func (l RekorV1MonitorLogic) Config() *notifications.IdentityMonitorConfiguration {
+	return l.config
+}
+
+func (l RekorV1MonitorLogic) MonitoredValues() identity.MonitoredValues {
+	return l.monitoredValues
+}
+
+func (l RekorV1MonitorLogic) Once() bool {
+	return l.flags.Once
+}
+
+func (l RekorV1MonitorLogic) NotificationContextNew() notifications.NotificationContext {
+	return notifications.CreateNotificationContext(
+		"rekor-monitor",
+		fmt.Sprintf("rekor-monitor workflow results for %s", time.Now().Format(time.RFC822)),
+	)
+}
+
+func (l RekorV1MonitorLogic) RunConsistencyCheck(ctx context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
+	prev, cur, err := rekor_v1.RunConsistencyCheck(l.rekorClient, l.verifier, l.flags.LogInfoFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	var prevCheckpoint cmd.Checkpoint
+	if prev != nil {
+		prevCheckpoint = prev
+	}
+	var curLogInfo cmd.LogInfo
+	if cur != nil {
+		curLogInfo = cur
+	}
+	return prevCheckpoint, curLogInfo, nil
+}
+
+func (l RekorV1MonitorLogic) WriteCheckpoint(prev cmd.Checkpoint, cur cmd.LogInfo) error {
+	prevCheckpoint, ok := prev.(*util.SignedCheckpoint)
+	if !ok && prev != nil {
+		return fmt.Errorf("prev is not a SignedCheckpoint")
+	}
+	curCheckpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
+	if err != nil {
+		return fmt.Errorf("failed to read latest checkpoint: %v", err)
+	}
+
+	// TODO: Switch to writing checkpoints to GitHub so that the history is preserved. Then we only need
+	// to persist the last checkpoint.
+	if err := file.WriteCheckpointRekorV1(curCheckpoint, prevCheckpoint, l.flags.LogInfoFile, false); err != nil {
+		return fmt.Errorf("failed to write checkpoint: %v", err)
+	}
+
+	return nil
+}
+
+func (l RekorV1MonitorLogic) GetStartIndex(prev cmd.Checkpoint, cur cmd.LogInfo) *int {
+	checkpointStartIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), prev.(*util.SignedCheckpoint))
+	return &checkpointStartIndex
+}
+
+func (l RekorV1MonitorLogic) GetEndIndex(cur cmd.LogInfo) *int {
+	checkpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
+	if err != nil {
+		return nil
+	}
+	checkpointEndIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), checkpoint)
+	return &checkpointEndIndex
+}
+
+func (l RekorV1MonitorLogic) IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+	return rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, l.rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
+}
+
+type RekorV2MonitorLogic struct {
+	tufClient         *tuf.Client
+	flags             *cmd.MonitorFlags
+	config            *notifications.IdentityMonitorConfiguration
+	rekorShards       map[string]rekor_v2.ShardInfo
+	latestShardOrigin string
+	monitoredValues   identity.MonitoredValues
+}
+
+func (l RekorV2MonitorLogic) Interval() time.Duration {
+	return l.flags.Interval
+}
+
+func (l RekorV2MonitorLogic) Config() *notifications.IdentityMonitorConfiguration {
+	return l.config
+}
+
+func (l RekorV2MonitorLogic) MonitoredValues() identity.MonitoredValues {
+	return l.monitoredValues
+}
+
+func (l RekorV2MonitorLogic) Once() bool {
+	return l.flags.Once
+}
+
+func (l RekorV2MonitorLogic) NotificationContextNew() notifications.NotificationContext {
+	return notifications.CreateNotificationContext(
+		"rekor-monitor-v2",
+		fmt.Sprintf("rekor-monitor v2 workflow results for %s", time.Now().Format(time.RFC822)),
+	)
+}
+
+func (l RekorV2MonitorLogic) RunConsistencyCheck(ctx context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
+	// On each iteration, we refresh the SigningConfig metadata and
+	// update the shards if we detect a change in the newest shard
+	signingConfig, err := rekor_v2.RefreshSigningConfig(l.tufClient)
+	if err != nil {
+		return nil, nil, err
+	}
+	shouldUpdate, err := rekor_v2.ShardsNeedUpdating(l.rekorShards, signingConfig)
+	if err != nil {
+		return nil, nil, err
+	}
+	if shouldUpdate {
+		trustedRoot, err := root.GetTrustedRoot(l.tufClient)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error getting trusted root: %v", err)
+		}
+		l.rekorShards, l.latestShardOrigin, err = rekor_v2.GetRekorShards(context.Background(), trustedRoot, signingConfig.RekorLogURLs(), l.flags.UserAgent)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error getting shards: %v", err)
+		}
+	}
+
+	prev, cur, err := rekor_v2.RunConsistencyCheck(context.Background(), l.rekorShards, l.latestShardOrigin, l.flags.LogInfoFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	var prevCheckpoint cmd.Checkpoint
+	if prev != nil {
+		prevCheckpoint = prev
+	}
+	var curLogInfo cmd.LogInfo
+	if cur != nil {
+		curLogInfo = cur
+	}
+	return prevCheckpoint, curLogInfo, nil
+}
+
+func (l RekorV2MonitorLogic) WriteCheckpoint(prev cmd.Checkpoint, cur cmd.LogInfo) error {
+	prevCheckpoint, ok := prev.(*tlog.Checkpoint)
+	if !ok && prev != nil {
+		return fmt.Errorf("prev is not a Checkpoint")
+	}
+	curCheckpoint, ok := cur.(*tlog.Checkpoint)
+	if !ok {
+		return fmt.Errorf("cur is not a Checkpoint")
+	}
+	if err := file.WriteCheckpointRekorV2(curCheckpoint, prevCheckpoint, l.flags.LogInfoFile, false); err != nil {
+		return fmt.Errorf("failed to write checkpoint: %v", err)
+	}
+	return nil
+}
+
+func (l RekorV2MonitorLogic) GetStartIndex(prev cmd.Checkpoint, cur cmd.LogInfo) *int {
+	return nil
+}
+
+func (l RekorV2MonitorLogic) GetEndIndex(cur cmd.LogInfo) *int {
+	return nil
+}
+
+func (l RekorV2MonitorLogic) IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
+	return nil, nil, nil
 }
 
 // This main function performs a periodic identity search.
@@ -160,128 +334,24 @@ func mainLoopV1(flags *cmd.MonitorFlags, config *notifications.IdentityMonitorCo
 	}
 
 	cmd.PrintMonitoredValues(monitoredValues)
-	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:                 flags.Interval,
-		Config:                   config,
-		MonitoredValues:          monitoredValues,
-		Once:                     flags.Once,
-		NotificationContextNewFn: CreateRekorMonitorNotificationContext,
-		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
-			prev, cur, err := rekor_v1.RunConsistencyCheck(rekorClient, verifier, flags.LogInfoFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			var prevCheckpoint cmd.Checkpoint
-			if prev != nil {
-				prevCheckpoint = prev
-			}
-			var curLogInfo cmd.LogInfo
-			if cur != nil {
-				curLogInfo = cur
-			}
-			return prevCheckpoint, curLogInfo, nil
-		},
-		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*util.SignedCheckpoint)
-			if !ok && prev != nil {
-				return fmt.Errorf("prev is not a SignedCheckpoint")
-			}
-			curCheckpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
-			if err != nil {
-				return fmt.Errorf("failed to read latest checkpoint: %v", err)
-			}
-
-			// TODO: Switch to writing checkpoints to GitHub so that the history is preserved. Then we only need
-			// to persist the last checkpoint.
-			if err := file.WriteCheckpointRekorV1(curCheckpoint, prevCheckpoint, flags.LogInfoFile, false); err != nil {
-				return fmt.Errorf("failed to write checkpoint: %v", err)
-			}
-
-			return nil
-		},
-		GetStartIndexFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) *int {
-			checkpointStartIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), prev.(*util.SignedCheckpoint))
-			return &checkpointStartIndex
-		},
-		GetEndIndexFn: func(cur cmd.LogInfo) *int {
-			checkpoint, err := rekor_v1.ReadLatestCheckpoint(cur.(*models.LogInfo))
-			if err != nil {
-				return nil
-			}
-			checkpointEndIndex := rekor_v1.GetCheckpointIndex(cur.(*models.LogInfo), checkpoint)
-			return &checkpointEndIndex
-		},
-		IdentitySearchFn: func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
-			return rekor_v1.IdentitySearch(ctx, *config.StartIndex, *config.EndIndex, rekorClient, monitoredValues, config.OutputIdentitiesFile, config.IdentityMetadataFile)
-		},
-	})
+	rekorV1MonitorLogic := RekorV1MonitorLogic{
+		rekorClient:     rekorClient,
+		verifier:        verifier,
+		flags:           flags,
+		config:          config,
+		monitoredValues: monitoredValues,
+	}
+	cmd.MonitorLoop(rekorV1MonitorLogic)
 }
 
 func mainLoopV2(tufClient *tuf.Client, flags *cmd.MonitorFlags, config *notifications.IdentityMonitorConfiguration, rekorShards map[string]rekor_v2.ShardInfo, latestShardOrigin string) {
-	cmd.MonitorLoop(cmd.MonitorLoopParams{
-		Interval:                 flags.Interval,
-		Config:                   config,
-		MonitoredValues:          identity.MonitoredValues{},
-		Once:                     flags.Once,
-		NotificationContextNewFn: CreateRekorMonitorNotificationContext,
-		RunConsistencyCheckFn: func(_ context.Context) (cmd.Checkpoint, cmd.LogInfo, error) {
-			// On each iteration, we refresh the SigningConfig metadata and
-			// update the shards if we detect a change in the newest shard
-			signingConfig, err := rekor_v2.RefreshSigningConfig(tufClient)
-			if err != nil {
-				return nil, nil, err
-			}
-			shouldUpdate, err := rekor_v2.ShardsNeedUpdating(rekorShards, signingConfig)
-			if err != nil {
-				return nil, nil, err
-			}
-			if shouldUpdate {
-				trustedRoot, err := root.GetTrustedRoot(tufClient)
-				if err != nil {
-					return nil, nil, fmt.Errorf("error getting trusted root: %v", err)
-				}
-				rekorShards, latestShardOrigin, err = rekor_v2.GetRekorShards(context.Background(), trustedRoot, signingConfig.RekorLogURLs(), flags.UserAgent)
-				if err != nil {
-					return nil, nil, fmt.Errorf("error getting shards: %v", err)
-				}
-			}
-
-			prev, cur, err := rekor_v2.RunConsistencyCheck(context.Background(), rekorShards, latestShardOrigin, flags.LogInfoFile)
-			if err != nil {
-				return nil, nil, err
-			}
-			var prevCheckpoint cmd.Checkpoint
-			if prev != nil {
-				prevCheckpoint = prev
-			}
-			var curLogInfo cmd.LogInfo
-			if cur != nil {
-				curLogInfo = cur
-			}
-			return prevCheckpoint, curLogInfo, nil
-		},
-		WriteCheckpointFn: func(prev cmd.Checkpoint, cur cmd.LogInfo) error {
-			prevCheckpoint, ok := prev.(*tlog.Checkpoint)
-			if !ok && prev != nil {
-				return fmt.Errorf("prev is not a Checkpoint")
-			}
-			curCheckpoint, ok := cur.(*tlog.Checkpoint)
-			if !ok {
-				return fmt.Errorf("cur is not a Checkpoint")
-			}
-			if err := file.WriteCheckpointRekorV2(curCheckpoint, prevCheckpoint, flags.LogInfoFile, false); err != nil {
-				return fmt.Errorf("failed to write checkpoint: %v", err)
-			}
-			return nil
-		},
-		GetStartIndexFn: func(_ cmd.Checkpoint, _ cmd.LogInfo) *int {
-			return nil
-		},
-		GetEndIndexFn: func(_ cmd.LogInfo) *int {
-			return nil
-		},
-		IdentitySearchFn: func(_ context.Context, _ *notifications.IdentityMonitorConfiguration, _ identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error) {
-			return nil, nil, nil
-		},
-	})
+	rekorV2MonitorLogic := RekorV2MonitorLogic{
+		tufClient:         tufClient,
+		flags:             flags,
+		config:            config,
+		rekorShards:       rekorShards,
+		latestShardOrigin: latestShardOrigin,
+		monitoredValues:   identity.MonitoredValues{},
+	}
+	cmd.MonitorLoop(rekorV2MonitorLogic)
 }

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -59,6 +59,19 @@ type MonitorLoopParams struct {
 	IdentitySearchFn         func(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error)
 }
 
+type MonitorLogic interface {
+	Interval() time.Duration
+	Config() *notifications.IdentityMonitorConfiguration
+	MonitoredValues() identity.MonitoredValues
+	Once() bool
+	NotificationContextNew() notifications.NotificationContext
+	RunConsistencyCheck(ctx context.Context) (Checkpoint, LogInfo, error)
+	WriteCheckpoint(prev Checkpoint, cur LogInfo) error
+	GetStartIndex(prev Checkpoint, cur LogInfo) *int
+	GetEndIndex(cur LogInfo) *int
+	IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorConfiguration, monitoredValues identity.MonitoredValues) ([]identity.MonitoredIdentity, []identity.FailedLogEntry, error)
+}
+
 type Checkpoint interface{}
 type LogInfo interface{}
 
@@ -160,37 +173,37 @@ func PrintMonitoredValues(monitoredValues identity.MonitoredValues) {
 	}
 }
 
-func MonitorLoop(params MonitorLoopParams) {
-	ticker := time.NewTicker(params.Interval)
+func MonitorLoop(loopLogic MonitorLogic) {
+	ticker := time.NewTicker(loopLogic.Interval())
 	defer ticker.Stop()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	config := params.Config
+	config := loopLogic.Config()
 
 	// To get an immediate first tick, for-select is at the end of the loop
 	for {
 		fmt.Fprint(os.Stderr, "New monitor run at ", time.Now().Format(time.RFC3339), "\n")
 		inputEndIndex := config.EndIndex
 
-		prevCheckpoint, curCheckpoint, err := params.RunConsistencyCheckFn(ctx)
+		prevCheckpoint, curCheckpoint, err := loopLogic.RunConsistencyCheck(ctx)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error running consistency check: %v", err)
 			return
 		}
 
-		if identity.MonitoredValuesExist(params.MonitoredValues) {
+		if identity.MonitoredValuesExist(loopLogic.MonitoredValues()) {
 			if config.StartIndex == nil {
 				if prevCheckpoint != nil {
-					config.StartIndex = params.GetStartIndexFn(prevCheckpoint, curCheckpoint)
+					config.StartIndex = loopLogic.GetStartIndex(prevCheckpoint, curCheckpoint)
 				} else {
 					fmt.Fprintf(os.Stderr, "no start index set and no log checkpoint, just saving checkpoint\n")
 				}
 			}
 
 			if config.EndIndex == nil {
-				config.EndIndex = params.GetEndIndexFn(curCheckpoint)
+				config.EndIndex = loopLogic.GetEndIndex(curCheckpoint)
 			}
 
 			if config.StartIndex != nil && config.EndIndex != nil {
@@ -199,7 +212,7 @@ func MonitorLoop(params MonitorLoopParams) {
 					return
 				}
 
-				foundEntries, failedEntries, err := params.IdentitySearchFn(ctx, config, params.MonitoredValues)
+				foundEntries, failedEntries, err := loopLogic.IdentitySearch(ctx, config, loopLogic.MonitoredValues())
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "failed to successfully complete identity search: %v", err)
 					return
@@ -210,7 +223,7 @@ func MonitorLoop(params MonitorLoopParams) {
 
 					if len(foundEntries) > 0 {
 						notificationData := notifications.NotificationData{
-							Context: params.NotificationContextNewFn(),
+							Context: loopLogic.NotificationContextNew(),
 							Payload: identity.MonitoredIdentityList(foundEntries),
 						}
 
@@ -224,7 +237,7 @@ func MonitorLoop(params MonitorLoopParams) {
 						fmt.Fprintf(os.Stderr, "failed to parse some log entries: %v", failedEntries)
 
 						notificationData := notifications.NotificationData{
-							Context: params.NotificationContextNewFn(),
+							Context: loopLogic.NotificationContextNew(),
 							Payload: identity.FailedLogEntryList(failedEntries),
 						}
 
@@ -243,12 +256,12 @@ func MonitorLoop(params MonitorLoopParams) {
 
 		// Write checkpoint after identity search to ensure identities are
 		// always searched even if something fails in the middle
-		if err := params.WriteCheckpointFn(prevCheckpoint, curCheckpoint); err != nil {
+		if err := loopLogic.WriteCheckpoint(prevCheckpoint, curCheckpoint); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to write checkpoint: %v", err)
 			return
 		}
 
-		if params.Once || inputEndIndex != nil {
+		if loopLogic.Once() || inputEndIndex != nil {
 			return
 		}
 


### PR DESCRIPTION
I think this is more golang-like and it also ensures we don't accidentally forget to implement some callbacks in the struct (thing that happened quite a bit while developing). 