### PR TITLE
Parsable output

### DIFF
--- a/cmd/ct_monitor/main.go
+++ b/cmd/ct_monitor/main.go
@@ -38,7 +38,7 @@ import (
 const (
 	publicCTServerURL        = "https://ctfe.sigstore.dev/2022"
 	logInfoFileName          = "ctLogInfo"
-	outputIdentitiesFileName = "ctIdentities.txt"
+	outputIdentitiesFileName = "ctIdentities"
 	TUFRepository            = "default"
 )
 

--- a/cmd/rekor_monitor/main.go
+++ b/cmd/rekor_monitor/main.go
@@ -43,7 +43,7 @@ import (
 const (
 	publicRekorServerURL     = "https://rekor.sigstore.dev"
 	TUFRepository            = "default"
-	outputIdentitiesFileName = "identities.txt"
+	outputIdentitiesFileName = "identities"
 	logInfoFileNamePrefix    = "logInfo"
 )
 

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -140,8 +140,18 @@ func LoadMonitorConfig(flags *MonitorFlags, defaultOutputFile string) (*notifica
 		}
 	}
 
+	if config.OutputIdentitiesFormat == "" {
+		config.OutputIdentitiesFormat = "text"
+	}
+
 	if config.OutputIdentitiesFile == "" {
 		config.OutputIdentitiesFile = defaultOutputFile
+		switch config.OutputIdentitiesFormat {
+		case "text":
+			config.OutputIdentitiesFile += ".txt"
+		case "json":
+			config.OutputIdentitiesFile += ".json"
+		}
 	}
 
 	if flags.CARootsFile != "" {

--- a/internal/cmd/common_test.go
+++ b/internal/cmd/common_test.go
@@ -152,7 +152,7 @@ func TestLoadMonitorConfig(t *testing.T) {
 				ConfigFile: "test.yaml",
 				ConfigYaml: "test: yaml",
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           true,
 			expectedConfig:    nil,
 		},
@@ -161,7 +161,7 @@ func TestLoadMonitorConfig(t *testing.T) {
 			flags: &MonitorFlags{
 				ConfigFile: "test.yaml",
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           false,
 			expectedOutput:    "custom.txt",
 			expectedConfig: &notifications.IdentityMonitorConfiguration{
@@ -200,7 +200,7 @@ monitoredValues:
 			flags: &MonitorFlags{
 				ConfigFile: "test.yaml",
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           true,
 			expectedConfig:    nil,
 			setupFiles: func(t *testing.T) (string, func()) {
@@ -221,7 +221,7 @@ monitoredValues:
 			flags: &MonitorFlags{
 				ConfigFile: "nonexistent.yaml",
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           true,
 			expectedConfig:    nil,
 		},
@@ -236,7 +236,7 @@ monitoredValues:
   fingerprints: ["test-fingerprint"]
   subjects: ["test-subject"]`,
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           false,
 			expectedOutput:    "custom.txt",
 			expectedConfig: &notifications.IdentityMonitorConfiguration{
@@ -257,7 +257,7 @@ monitoredValues:
 			flags: &MonitorFlags{
 				ConfigYaml: `invalid: yaml: content: with: too: many: colons`,
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           true,
 			expectedConfig:    nil,
 		},
@@ -267,7 +267,7 @@ monitoredValues:
 				ConfigFile: "",
 				ConfigYaml: "",
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           false,
 			expectedOutput:    "default.txt",
 			expectedConfig:    &notifications.IdentityMonitorConfiguration{},
@@ -280,7 +280,7 @@ monitoredValues:
     - certSubject: "test-subject"
   fingerprints: ["test-fingerprint"]`,
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           false,
 			expectedOutput:    "default.txt",
 			expectedConfig: &notifications.IdentityMonitorConfiguration{
@@ -309,7 +309,7 @@ monitoredValues:
       issuers: ["O=Test Org", "O=Another Org"]
     - certSubject: "CN=another.example.com"
       issuers: ["O=Test Org"]
-  fingerprints: 
+  fingerprints:
     - "sha256:abcdef1234567890"
     - "sha256:fedcba0987654321"
   subjects:
@@ -321,7 +321,7 @@ githubIssue:
 emailNotificationSMTP:
   SMTPHostURL: "smtp.example.com"`,
 			},
-			defaultOutputFile: "default.txt",
+			defaultOutputFile: "default",
 			wantErr:           false,
 			expectedOutput:    "complex.txt",
 			expectedConfig: &notifications.IdentityMonitorConfiguration{
@@ -402,7 +402,7 @@ func TestLoadMonitorConfig_ConfigFilePermissions(t *testing.T) {
 		ConfigFile: configFile,
 	}
 
-	_, err = LoadMonitorConfig(flags, "default.txt")
+	_, err = LoadMonitorConfig(flags, "default")
 	if err == nil {
 		t.Errorf("LoadMonitorConfig() expected error for file with no read permissions but got none")
 	}
@@ -422,7 +422,7 @@ func TestLoadMonitorConfig_EmptyConfigFile(t *testing.T) {
 		ConfigFile: configFile,
 	}
 
-	config, err := LoadMonitorConfig(flags, "default.txt")
+	config, err := LoadMonitorConfig(flags, "default")
 	if err != nil {
 		t.Errorf("LoadMonitorConfig() unexpected error for empty file: %v", err)
 		return
@@ -456,7 +456,7 @@ monitoredValues:
     - "user.name@domain.com"`,
 	}
 
-	config, err := LoadMonitorConfig(flags, "default.txt")
+	config, err := LoadMonitorConfig(flags, "default")
 	if err != nil {
 		t.Errorf("LoadMonitorConfig() unexpected error for YAML with special characters: %v", err)
 		return

--- a/pkg/ct/monitor.go
+++ b/pkg/ct/monitor.go
@@ -148,7 +148,7 @@ func IdentitySearch(ctx context.Context, client *ctclient.LogClient, config *not
 		return nil, nil, err
 	}
 
-	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
+	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, config.OutputIdentitiesFormat, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -96,6 +96,7 @@ type IdentityMonitorConfiguration struct {
 	EndIndex                  *int64                     `yaml:"endIndex"`
 	MonitoredValues           ConfigMonitoredValues      `yaml:"monitoredValues"`
 	OutputIdentitiesFile      string                     `yaml:"outputIdentities"`
+	OutputIdentitiesFormat    string                     `yaml:"outputIdentitiesFormat"`
 	LogInfoFile               string                     `yaml:"logInfoFile"`
 	IdentityMetadataFile      *string                    `yaml:"identityMetadataFile"`
 	GitHubIssue               *GitHubIssueInput          `yaml:"githubIssue"`
@@ -153,6 +154,12 @@ func (c *IdentityMonitorConfiguration) Validate() error {
 	}
 	if err := validatePEMFile(c.CAIntermediatesFile); err != nil {
 		return fmt.Errorf("invalid CAIntermediates file %s: %v", c.CAIntermediatesFile, err)
+	}
+	// Validate OutputIdentitiesFormat
+	switch c.OutputIdentitiesFormat {
+	case "text", "json", "":
+	default:
+		return fmt.Errorf("invalid OutputIdentitiesFormat %s: must be 'text' or 'json'", c.OutputIdentitiesFormat)
 	}
 	return nil
 }

--- a/pkg/rekor/v1/identity.go
+++ b/pkg/rekor/v1/identity.go
@@ -279,7 +279,7 @@ func IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorCo
 		return nil, nil, fmt.Errorf("error matching indices: %v", err)
 	}
 
-	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
+	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, config.OutputIdentitiesFormat, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/rekor/v2/identity.go
+++ b/pkg/rekor/v2/identity.go
@@ -263,7 +263,7 @@ func IdentitySearch(ctx context.Context, config *notifications.IdentityMonitorCo
 		return nil, nil, fmt.Errorf("error matching indices: %v", err)
 	}
 
-	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
+	err = file.WriteMatchedIdentityEntries(config.OutputIdentitiesFile, config.OutputIdentitiesFormat, matchedEntries, config.IdentityMetadataFile, *config.EndIndex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
+++ b/pkg/test/rekor_e2e/rekor_monitor_e2e_test.go
@@ -269,11 +269,12 @@ func TestIdentitySearch(t *testing.T) {
 	startIndex := int64(0)
 	endIndex := int64(1)
 	config := &notifications.IdentityMonitorConfiguration{
-		StartIndex:           &startIndex,
-		EndIndex:             &endIndex,
-		CARootsFile:          "",
-		CAIntermediatesFile:  "",
-		OutputIdentitiesFile: tempOutputIdentitiesFileName,
+		StartIndex:             &startIndex,
+		EndIndex:               &endIndex,
+		CARootsFile:            "",
+		CAIntermediatesFile:    "",
+		OutputIdentitiesFile:   tempOutputIdentitiesFileName,
+		OutputIdentitiesFormat: "text",
 	}
 	_, _, err = rekor_v1.IdentitySearch(context.Background(), config, rekorClient, monitoredVals)
 	if err != nil {


### PR DESCRIPTION
Add field `outputIdentitiesFormat` to config file to specify either `text` or `json`.

When using JSON, the identity file is written as JSONL, so it can be more easily parsed.