### PR TITLE
pkg/identity: validate OID extensions with x509.ParseOID

### DIFF
--- a/pkg/ct/v1/monitor_test.go
+++ b/pkg/ct/v1/monitor_test.go
@@ -175,7 +175,7 @@ func TestScanEntryOIDExtension(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil got %v", err)
 	}
-	unmatchedAsn1OID := asn1.ObjectIdentifier{2}
+	unmatchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 18}
 	matchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 17}
 	extValueString := "test cert value"
 
@@ -264,7 +264,7 @@ func TestMatchedIndices(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected nil got %v", err)
 	}
-	unmatchedAsn1OID := asn1.ObjectIdentifier{2}
+	unmatchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 18}
 	matchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 17}
 	extValueString := "test cert value"
 	extCert.Extensions = append(extCert.Extensions, pkix.Extension{

--- a/pkg/ct/v2/monitor_test.go
+++ b/pkg/ct/v2/monitor_test.go
@@ -49,7 +49,7 @@ func TestMatchedIndices(t *testing.T) {
 			Value: value,
 		},
 	}
-	unmatchedAsn1OID := asn1.ObjectIdentifier{2}
+	unmatchedAsn1OID := asn1.ObjectIdentifier{2, 5, 29, 18}
 	matchedAsn1OID := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 99999}
 	extValueString := "test cert value"
 	extensions = append(extensions, pkix.Extension{

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -147,14 +147,13 @@ func (o OIDMatcherValue) MarshalJSON() ([]byte, error) {
 		"extensionValues": o.ExtensionValues,
 	})
 }
+
 func (o OIDMatcherValue) Verify() error {
 	if len(o.OID) == 0 {
 		return errors.New("oid extension empty")
 	}
-	for i, component := range o.OID {
-		if component < 0 {
-			return fmt.Errorf("oid component %d is negative: %d", i, component)
-		}
+	if _, err := x509.ParseOID(o.OID.String()); err != nil {
+		return fmt.Errorf("oid extension invalid: %w", err)
 	}
 	if len(o.ExtensionValues) == 0 {
 		return errors.New("oid matched values empty")

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -549,3 +549,44 @@ func TestOIDMatcherValueVerifyValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestOIDMatcherValueVerify_InvalidOID(t *testing.T) {
+	testCases := []struct {
+		name        string
+		oid         asn1.ObjectIdentifier
+		expectedErr string
+	}{
+		{
+			name:        "too short",
+			oid:         asn1.ObjectIdentifier{1},
+			expectedErr: "invalid oid",
+		},
+		{
+			name:        "negative arc",
+			oid:         asn1.ObjectIdentifier{1, -1},
+			expectedErr: "invalid oid",
+		},
+		{
+			name:        "first arc too large",
+			oid:         asn1.ObjectIdentifier{3, 1},
+			expectedErr: "invalid oid",
+		},
+		{
+			name:        "second arc too large",
+			oid:         asn1.ObjectIdentifier{1, 40},
+			expectedErr: "invalid oid",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := OIDMatcherValue{
+				OID:             tc.oid,
+				ExtensionValues: []string{"val"},
+			}.Verify()
+			if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.expectedErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace the manual negative-component check in OIDMatcherValue.Verify with x509.ParseOID, which rejects malformed OIDs (too few arcs, first arc > 2, second arc >= 40, and so on). Fix CT monitor tests whose placeholder OID {2} is invalid under the stricter check.