### PR TITLE
Make MatchedIndices context-aware so it can be CTRL-C while iterating

### DIFF
--- a/pkg/ct/v1/monitor.go
+++ b/pkg/ct/v1/monitor.go
@@ -72,10 +72,15 @@ func rawPrecert(logEntry ct.LogEntry) []byte {
 	return logEntry.Precert.TBSCertificate.Raw
 }
 
-func MatchedIndices(logEntries []ct.LogEntry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
+func MatchedIndices(ctx context.Context, logEntries []ct.LogEntry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
 	matchedEntries := []identity.LogEntry{}
 	failedEntries := []identity.FailedLogEntry{}
 	for _, entry := range logEntries {
+		// Bail out promptly on cancellation: verifying a large backlog of
+		// entries can take a while, so honor ctx between entries.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		err := common.ValidateCertificateChain(rawCert(entry), rawPrecert(entry), caRoots, caIntermediates)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error validating chain for log entry at index %d: %v\n", entry.Index, err)
@@ -119,7 +124,7 @@ func IdentitySearch(ctx context.Context, client *ctclient.LogClient, monitoredVa
 	if err != nil {
 		return nil, nil, err
 	}
-	matchedEntries, failedEntries, err := MatchedIndices(entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
+	matchedEntries, failedEntries, err := MatchedIndices(ctx, entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ct/v1/monitor_test.go
+++ b/pkg/ct/v1/monitor_test.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/asn1"
 	"reflect"
 	"testing"
@@ -361,7 +362,7 @@ func TestMatchedIndices(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		matchedEntries, failedEntries, err := MatchedIndices(tc.inputEntries, tc.inputMonitoredValues, "", "")
+		matchedEntries, failedEntries, err := MatchedIndices(context.Background(), tc.inputEntries, tc.inputMonitoredValues, "", "")
 		if err != nil {
 			t.Errorf("error matching indices: %v", err)
 		}

--- a/pkg/ct/v2/monitor.go
+++ b/pkg/ct/v2/monitor.go
@@ -60,7 +60,7 @@ func ScanEntryOIDExtension(logEntry Entry, monitoredOID identity.OIDMatcherValue
 	return common.ScanEntryOIDExtension(cert, logEntry.Index, monitoredOID)
 }
 
-func MatchedIndices(logEntries []Entry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
+func MatchedIndices(ctx context.Context, logEntries []Entry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
 	if err := identity.VerifyMonitoredValues(mvs); err != nil {
 		return nil, nil, err
 	}
@@ -69,6 +69,11 @@ func MatchedIndices(logEntries []Entry, mvs identity.MonitoredValues, caRoots st
 	failedEntries := []identity.FailedLogEntry{}
 
 	for _, entry := range logEntries {
+		// Bail out promptly on cancellation: verifying a large backlog of
+		// entries can take a while, so honor ctx between entries.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		err := common.ValidateCertificateChain(entry.Entry.Certificate, entry.Entry.Precertificate, caRoots, caIntermediates)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error validating chain for log entry at index %d: %v\n", entry.Index, err)
@@ -110,7 +115,7 @@ func IdentitySearch(ctx context.Context, client *Client, monitoredValues identit
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting entries by index range: %w", err)
 	}
-	matchedEntries, failedEntries, err := MatchedIndices(entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
+	matchedEntries, failedEntries, err := MatchedIndices(ctx, entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("looking for matching entries: %w", err)
 	}

--- a/pkg/ct/v2/monitor_test.go
+++ b/pkg/ct/v2/monitor_test.go
@@ -15,6 +15,7 @@
 package v2
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -185,7 +186,7 @@ func TestMatchedIndices(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			matchedEntries, failedEntries, err := MatchedIndices(tc.inputEntries, tc.inputMonitoredValues, "", "")
+			matchedEntries, failedEntries, err := MatchedIndices(context.Background(), tc.inputEntries, tc.inputMonitoredValues, "", "")
 			if tc.expectErr {
 				if err == nil {
 					t.Errorf("expected error, got none")

--- a/pkg/rekor/v1/identity.go
+++ b/pkg/rekor/v1/identity.go
@@ -121,7 +121,7 @@ func MatchLogEntryOID(logEntryAnon models.LogEntryAnon, uuid string, entryCertif
 }
 
 // MatchedIndices returns a list of log indices that contain the requested identities.
-func MatchedIndices(logEntries []models.LogEntry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
+func MatchedIndices(ctx context.Context, logEntries []models.LogEntry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
 	if err := identity.VerifyMonitoredValues(mvs); err != nil {
 		return nil, nil, err
 	}
@@ -131,6 +131,11 @@ func MatchedIndices(logEntries []models.LogEntry, mvs identity.MonitoredValues, 
 
 	for _, entries := range logEntries {
 		for uuid, entry := range entries {
+			// Bail out promptly on cancellation: verifying a large backlog of
+			// entries can take a while, so honor ctx between entries.
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
 			verifiers, err := extractVerifiers(&entry)
 			if err != nil {
 				failedEntries = append(failedEntries, identity.FailedLogEntry{
@@ -268,7 +273,7 @@ func IdentitySearch(ctx context.Context, rekorClient *client.Rekor, monitoredVal
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting entries by index range: %v", err)
 	}
-	matchedEntries, failedEntries, err := MatchedIndices(entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
+	matchedEntries, failedEntries, err := MatchedIndices(ctx, entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error matching indices: %v", err)
 	}

--- a/pkg/rekor/v1/identity_test.go
+++ b/pkg/rekor/v1/identity_test.go
@@ -105,7 +105,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: subject,
 		},
@@ -133,7 +133,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// match to subject and issuer with certificate in hashedrekord
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: subject,
 			Issuers:     []string{issuer},
@@ -150,7 +150,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 	}
 
 	// match with regex subject and regex issuer with certificate in hashedrekord
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*ubje.*",
 			Issuers:     []string{".+@domain.com"},
@@ -196,7 +196,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		}
 		logEntry := models.LogEntry{uuid: logEntryAnon}
 
-		matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+		matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 			identity.CertIdentityValue{
 				CertSubject: ".*ubje.*",
 				Issuers:     []string{".+@domain.com"},
@@ -227,7 +227,7 @@ func TestMatchedIndicesForCertificates(t *testing.T) {
 		},
 	}
 	for _, monitoredValues := range testedMonitoredValues {
-		matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, monitoredValues, "", "")
+		matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, monitoredValues, "", "")
 		if err != nil {
 			t.Fatalf("expected error matching IDs, got %v", err)
 		}
@@ -288,7 +288,7 @@ func TestMatchedIndicesForDeprecatedCertificates(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: subject,
 			Issuers:     []string{issuer},
@@ -368,7 +368,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	fp := hex.EncodeToString(digest[:])
 
 	//  match to key fingerprint in hashedrekord
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.FingerprintValue{Fingerprint: fp},
 	}, "", "")
 	if err != nil {
@@ -391,7 +391,7 @@ func TestMatchedIndicesForFingerprints(t *testing.T) {
 	}
 
 	// no match with different fingerprints
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.FingerprintValue{Fingerprint: "other-fp"},
 	}, "", "")
 	if err != nil {
@@ -451,7 +451,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	//  match to subject with certificate in hashedrekord
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.SubjectValue{Subject: subject},
 	}, "", "")
 	if err != nil {
@@ -474,7 +474,7 @@ func TestMatchedIndicesForSubjects(t *testing.T) {
 	}
 
 	// no match with different subjects
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.SubjectValue{Subject: "other-sub"},
 	}, "", "")
 	if err != nil {
@@ -546,7 +546,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 	logEntry := models.LogEntry{uuid: logEntryAnon}
 
 	// match to oid with matching extension value
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, identity.MonitoredValues{
 		identity.OIDMatcherValue{
 			OID:             oid,
 			ExtensionValues: []string{extValueString},
@@ -583,7 +583,7 @@ func TestMatchedIndicesForOIDMatchers(t *testing.T) {
 		},
 	}
 	for _, monitoredValues := range testedMonitoredValues {
-		matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, monitoredValues, "", "")
+		matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, monitoredValues, "", "")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -664,7 +664,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
 	mvs := convertRenderedOIDMatchers(renderedOIDMatchers)
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, mvs, "", "")
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, mvs, "", "")
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
@@ -692,7 +692,7 @@ func TestMatchedIndicesForFulcioOIDMatchers(t *testing.T) {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
 	mvs = convertRenderedOIDMatchers(renderedOIDMatchers)
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, mvs, "", "")
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, mvs, "", "")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -775,7 +775,7 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
 	mvs := convertRenderedOIDMatchers(renderedOIDMatchers)
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{logEntry}, mvs, "", "")
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, mvs, "", "")
 	if err != nil {
 		t.Fatalf("expected error matching IDs, got %v", err)
 	}
@@ -809,7 +809,7 @@ func TestMatchedIndicesForCustomOIDMatchers(t *testing.T) {
 		t.Fatalf("received error rendering OID matchers: %v", err)
 	}
 	mvs = convertRenderedOIDMatchers(renderedOIDMatchers)
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{logEntry}, mvs, "", "")
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{logEntry}, mvs, "", "")
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -886,7 +886,7 @@ func TestMatchedIndicesFailures(t *testing.T) {
 
 	for name, testCase := range monitoredValuesTests {
 		t.Run(name, func(t *testing.T) {
-			_, _, err := MatchedIndices(nil, testCase.input, "", "")
+			_, _, err := MatchedIndices(context.Background(), nil, testCase.input, "", "")
 			if err == nil || !strings.Contains(err.Error(), testCase.errorString) {
 				t.Fatalf("expected error %v, received %v", testCase.errorString, err)
 			}
@@ -985,7 +985,7 @@ func TestMatchedIndicesWithTrustedCAs(t *testing.T) {
 	untrustedLogEntry := createLogEntry(untrustedLeafCert, untrustedLeafKey, "untrusted-uuid")
 
 	// Test with trusted CAs provided - should only match trusted certificate
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},
@@ -1007,7 +1007,7 @@ func TestMatchedIndicesWithTrustedCAs(t *testing.T) {
 	}
 
 	// Test with no trusted CAs provided - should match both certificates
-	matches, failedEntries, err = MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, failedEntries, err = MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},
@@ -1146,7 +1146,7 @@ func TestMatchedIndicesWithCARootsAndIntermediates(t *testing.T) {
 
 	// Test the core functionality: proper root-intermediate-leaf chain validation
 	// Should only match the trusted certificate chain (Root CA -> Intermediate CA -> Leaf Cert)
-	matches, failedEntries, err := MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},
@@ -1168,7 +1168,7 @@ func TestMatchedIndicesWithCARootsAndIntermediates(t *testing.T) {
 	}
 
 	// Test that we should not match any certificates because the untrusted intermediate CA is not signed by the trusted root CA
-	matches, _, err = MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, _, err = MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},
@@ -1183,7 +1183,7 @@ func TestMatchedIndicesWithCARootsAndIntermediates(t *testing.T) {
 
 	// Test that we should not match any certificates because the trusted intermediate CA is not signed by the untrusted root CA
 	untrustedRootFile := createTempCertFile(t, untrustedRootCert, "untrusted-root-ca")
-	matches, _, err = MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, _, err = MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},
@@ -1197,7 +1197,7 @@ func TestMatchedIndicesWithCARootsAndIntermediates(t *testing.T) {
 	}
 
 	// Make sure the untrusted chain is actually good to use with the right caRoots and caIntermediates
-	matches, _, err = MatchedIndices([]models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
+	matches, _, err = MatchedIndices(context.Background(), []models.LogEntry{trustedLogEntry, untrustedLogEntry}, identity.MonitoredValues{
 		identity.CertIdentityValue{
 			CertSubject: ".*@example.com",
 			Issuers:     []string{issuer},

--- a/pkg/rekor/v2/identity.go
+++ b/pkg/rekor/v2/identity.go
@@ -168,7 +168,7 @@ func extractAllIdentities(verifiers []verifier.Verifier) ([]string, []*x509.Cert
 }
 
 // MatchedIndices returns a list of log entries that contain the requested identities.
-func MatchedIndices(logEntries []Entry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
+func MatchedIndices(ctx context.Context, logEntries []Entry, mvs identity.MonitoredValues, caRoots string, caIntermediates string) ([]identity.LogEntry, []identity.FailedLogEntry, error) {
 	if err := identity.VerifyMonitoredValues(mvs); err != nil {
 		return nil, nil, err
 	}
@@ -177,6 +177,11 @@ func MatchedIndices(logEntries []Entry, mvs identity.MonitoredValues, caRoots st
 	var failedEntries []identity.FailedLogEntry
 
 	for _, entry := range logEntries {
+		// Bail out promptly on cancellation: verifying a large backlog of
+		// entries can take a while, so honor ctx between entries.
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		verifiers, err := extractVerifiers(entry.ProtoEntry)
 		if err != nil {
 			failedEntries = append(failedEntries, identity.FailedLogEntry{
@@ -253,7 +258,7 @@ func IdentitySearch(ctx context.Context, rekorShards map[string]ShardInfo, lates
 		return nil, nil, fmt.Errorf("error getting entries by index range: %v", err)
 	}
 
-	matchedEntries, failedEntries, err := MatchedIndices(entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
+	matchedEntries, failedEntries, err := MatchedIndices(ctx, entries, monitoredValues, o.CARootsFile, o.CAIntermediatesFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error matching indices: %v", err)
 	}


### PR DESCRIPTION
Sometimes you might have a long list of entries to match and doing CTRL-C while rekor-monitor is in that loop is ignored until the full list is processed. This patch fixes that behaviour by checking in-loop if the context has been cancelled.