### PR TITLE
rekor/v1: check entry body type before asserting to string

### DIFF
--- a/pkg/rekor/v1/identity.go
+++ b/pkg/rekor/v1/identity.go
@@ -211,7 +211,11 @@ func MatchedIndices(ctx context.Context, logEntries []models.LogEntry, mvs ident
 // extractVerifiers extracts a set of keys or certificates that can verify an
 // artifact signature from a Rekor entry
 func extractVerifiers(e *models.LogEntryAnon) ([]pki.PublicKey, error) {
-	b, err := base64.StdEncoding.DecodeString(e.Body.(string))
+	body, ok := e.Body.(string)
+	if !ok {
+		return nil, fmt.Errorf("entry body is not a string, got %T", e.Body)
+	}
+	b, err := base64.StdEncoding.DecodeString(body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rekor/v1/identity_test.go
+++ b/pkg/rekor/v1/identity_test.go
@@ -1214,6 +1214,51 @@ func TestMatchedIndicesWithCARootsAndIntermediates(t *testing.T) {
 	}
 }
 
+// TestMatchedIndicesNonStringBody verifies that a log entry whose Body is not a
+// base64 string (for example a JSON number that decodes to float64, or a nil
+// body) is reported as a failed entry instead of panicking. LogEntryAnon.Body is
+// an interface{} taken verbatim from the log response, so an unchecked type
+// assertion on it would crash the monitor process on malformed input.
+func TestMatchedIndicesNonStringBody(t *testing.T) {
+	logIndex := int64(1234)
+	mvs := identity.MonitoredValues{
+		identity.SubjectValue{Subject: subject},
+	}
+
+	nonStringBodies := map[string]interface{}{
+		"float64 body": float64(42),
+		"map body":     map[string]interface{}{"kind": "hashedrekord"},
+		"nil body":     nil,
+	}
+
+	for name, body := range nonStringBodies {
+		t.Run(name, func(t *testing.T) {
+			logEntryAnon := models.LogEntryAnon{
+				Body:     body,
+				LogIndex: conv.Pointer(logIndex),
+			}
+			logEntry := models.LogEntry{"non-string-uuid": logEntryAnon}
+
+			matches, failedEntries, err := MatchedIndices(context.Background(), []models.LogEntry{logEntry}, mvs, "", "")
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if len(matches) != 0 {
+				t.Fatalf("expected 0 matches, got %d", len(matches))
+			}
+			if len(failedEntries) != 1 {
+				t.Fatalf("expected 1 failed entry, got %d", len(failedEntries))
+			}
+			if failedEntries[0].Index != logIndex {
+				t.Fatalf("expected failed entry index %d, got %d", logIndex, failedEntries[0].Index)
+			}
+			if !strings.Contains(failedEntries[0].Error, "error extracting verifiers") {
+				t.Fatalf("expected verifier extraction error, got %q", failedEntries[0].Error)
+			}
+		})
+	}
+}
+
 func TestGetCheckpointIndex(t *testing.T) {
 	shardTreeSize := int64(1)
 	inactiveShard := models.InactiveShardLogInfo{


### PR DESCRIPTION
`extractVerifiers` decodes the entry body with an unchecked type assertion, `base64.StdEncoding.DecodeString(e.Body.(string))`. `LogEntryAnon.Body` is an `interface{}` taken verbatim from the `SearchLogQuery` response, so an entry whose body is nil or any non-string JSON type (a number decodes to `float64`, an object to a `map`) makes the assertion panic.

`MatchedIndices` deliberately routes extraction errors into a `FailedLogEntry` and keeps going, but a panic is not an error, and there is no `recover` anywhere in the package, so this crashes the monitor process. A crashed monitor stops watching the log, which is the availability property a transparency-log monitor is meant to provide.

This uses a comma-ok assertion and returns an error for a non-string body, so it flows through the existing failed-entry path instead of panicking. The v2 sibling `extractVerifiers` already guards its input this way. I added a regression test that drives `MatchedIndices` with a non-string body and confirms it is reported as a failed entry rather than crashing.

Note this is a defensive fix: a well-behaved Rekor instance always returns a base64 string body, so the malformed shape comes from a faulty or adversarial log response.
