### PR TITLE
Replace `detect-workflow-js` action by `job` context

### DIFF
--- a/.github/workflows/base_monitoring.yml
+++ b/.github/workflows/base_monitoring.yml
@@ -58,18 +58,12 @@ on:
 
 permissions:
   contents: read
-  id-token: write
   issues: write
 
 jobs:
   detect-workflow:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      id-token: write # Needed to detect the current reusable repository and ref.
-    outputs:
-      repository: ${{ steps.detect.outputs.repository }}
-      ref: ${{ steps.detect.outputs.ref }}
     steps:
       - name: Check monitor type
         run: |
@@ -79,9 +73,6 @@ jobs:
           fi
         env:
           INPUT_MONITOR_TYPE: ${{ inputs.monitor_type }}
-      - name: Detect the repository and ref
-        id: detect
-        uses: slsa-framework/slsa-github-generator/.github/actions/detect-workflow-js@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     # NOTE: This GHA should not be run concurrently.
     concurrency:
       group: ${{ inputs.monitor_type }}-consistency-check
@@ -94,8 +85,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
+          repository: ${{ job.workflow_repository }}
+          ref: "${{ job.workflow_sha }}"
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: './go.mod'
@@ -115,7 +106,7 @@ jobs:
           go run ./cmd/rekor_monitor \
             --file ${{ inputs.checkpoint_file }} \
             --once=${{ inputs.once }} \
-            --user-agent "${{ format('{0}/{1}/{2}', needs.detect-workflow.outputs.repository, needs.detect-workflow.outputs.ref, github.run_id) }}" \
+            --user-agent "${{ format('{0}/{1}/{2}', job.workflow_repository, job.workflow_sha, github.run_id) }}" \
             --config "${{ inputs.config }}" \
             ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
       - if: ${{ inputs.monitor_type == 'ct' }}
@@ -140,7 +131,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       issues: write
-      id-token: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ISSUE_REPOSITORY: ${{ github.repository }}
@@ -148,8 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
+          repository: ${{ job.workflow_repository }}
+          ref: "${{ job.workflow_sha }}"
       - run: |
           set -euo pipefail
           ./.github/workflows/scripts/report_success.sh
@@ -167,8 +157,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          repository: ${{ needs.detect-workflow.outputs.repository }}
-          ref: "${{ needs.detect-workflow.outputs.ref }}"
+          repository: ${{ job.workflow_repository }}
+          ref: "${{ job.workflow_sha }}"
       - run: |
           set -euo pipefail
           ./.github/workflows/scripts/report_failure.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      id-token: write # Needed to detect the current reusable repository and ref
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true

--- a/.github/workflows/ct_reusable_monitoring.yml
+++ b/.github/workflows/ct_reusable_monitoring.yml
@@ -42,7 +42,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
   issues: write
 
 jobs:

--- a/.github/workflows/reusable_monitoring.yml
+++ b/.github/workflows/reusable_monitoring.yml
@@ -42,7 +42,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
   issues: write
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ jobs:
     permissions:
       contents: read # Needed to checkout repositories
       issues: write # Needed if you set "file_issue: true"
-      id-token: write # Needed to detect the current reusable repository and ref
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true # Strongly recommended: Files an issue on monitoring failure
@@ -169,7 +168,6 @@ jobs:
     permissions:
       contents: read # Needed to checkout repositories
       issues: write # Needed if you set "file_issue: true"
-      id-token: write # Needed to detect the current reusable repository and ref
     uses: sigstore/rekor-monitor/.github/workflows/reusable_monitoring.yml@main
     with:
       file_issue: true # Strongly recommended: Files an issue on monitoring failure
@@ -323,7 +321,6 @@ jobs:
     permissions:
       contents: read # Needed to checkout repositories
       issues: write # Needed if you set "file_issue: true"
-      id-token: write # Needed to detect the current reusable repository and ref
     uses: sigstore/rekor-monitor/.github/workflows/ct_reusable_monitoring.yml@main
     with:
       file_issue: true # Strongly recommended: Files an issue on monitoring failure


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Remove the use of `slsa-framework/slsa-github-generator/.github/ actions/detect-workflow-js`, and by extension drop the need for the `id-token: write` permission, by the [`job` context](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#job-context). This context contains the information previously obtained with that action, without requiring a sensitive permission.

- This addresses the primary concern voiced in #832.
- This resolves #1020 by removing the dependency on `slsa-framework/slsa-github-generator` altogether.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
- Remove the `id-token: write` permission requirement from reusable workflows.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

I updated the docs in this project, I'm unaware of any docs on <https://docs.sigstore.dev> for this.
