### PR TITLE
Harden CI based on zizmor

### DIFF
--- a/.github/workflows/base_monitoring.yml
+++ b/.github/workflows/base_monitoring.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           repository: ${{ job.workflow_repository }}
           ref: "${{ job.workflow_sha }}"
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: './go.mod'
@@ -98,24 +99,37 @@ jobs:
         # Skip on first run since there will be no checkpoint
         continue-on-error: true
       - name: Log current checkpoints
-        run: cat ${{ inputs.checkpoint_file }}
+        env:
+          CHECKPOINT_FILE: ${{ inputs.checkpoint_file }}
+        run: cat "$CHECKPOINT_FILE"
         # Skip on first run
         continue-on-error: true
       - if: ${{ inputs.monitor_type == 'rekor' }}
+        env:
+          CHECKPOINT_FILE: ${{ inputs.checkpoint_file }}
+          CONFIG: ${{ inputs.config }}
+          ONCE: ${{ inputs.once }}
+          USER_AGENT: ${{ format('{0}/{1}/{2}', job.workflow_repository, job.workflow_sha, github.run_id) }}
+          URL: ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
         run: |
           go run ./cmd/rekor_monitor \
-            --file ${{ inputs.checkpoint_file }} \
-            --once=${{ inputs.once }} \
-            --user-agent "${{ format('{0}/{1}/{2}', job.workflow_repository, job.workflow_sha, github.run_id) }}" \
-            --config "${{ inputs.config }}" \
-            ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
+            --file "$CHECKPOINT_FILE" \
+            --once="$ONCE" \
+            --user-agent "$USER_AGENT" \
+            --config "$CONFIG" \
+            "$URL"
       - if: ${{ inputs.monitor_type == 'ct' }}
+        env:
+          CHECKPOINT_FILE: ${{ inputs.checkpoint_file }}
+          CONFIG: ${{ inputs.config }}
+          ONCE: ${{ inputs.once }}
+          URL: ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
         run: |
           go run ./cmd/ct_monitor \
-            --config "${{ inputs.config }}" \
-            --file ${{ inputs.checkpoint_file }} \
-            --once=${{ inputs.once }} \
-            ${{ inputs.url && format('--url {0}', inputs.url) || '' }}
+            --config "$CONFIG" \
+            --file "$CHECKPOINT_FILE" \
+            --once="$ONCE" \
+            "$URL"
       - name: Upload checkpoint
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -123,7 +137,9 @@ jobs:
           path: ${{ inputs.checkpoint_file }}
           retention-days: ${{ inputs.artifact_retention_days }}
       - name: Log new checkpoints
-        run: cat ${{ inputs.checkpoint_file }}
+        env:
+          CHECKPOINT_FILE: ${{ inputs.checkpoint_file }}
+        run: cat "$CHECKPOINT_FILE"
 
   if-succeeded:
     runs-on: ubuntu-latest
@@ -140,6 +156,7 @@ jobs:
         with:
           repository: ${{ job.workflow_repository }}
           ref: "${{ job.workflow_sha }}"
+          persist-credentials: false
       - run: |
           set -euo pipefail
           ./.github/workflows/scripts/report_success.sh
@@ -159,6 +176,7 @@ jobs:
         with:
           repository: ${{ job.workflow_repository }}
           ref: "${{ job.workflow_sha }}"
+          persist-credentials: false
       - run: |
           set -euo pipefail
           ./.github/workflows/scripts/report_failure.sh

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -24,5 +24,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -70,6 +72,8 @@ jobs:
 
     steps: 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: './go.mod'
@@ -42,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: './go.mod'


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Harden the CI workflows, internal and external, in two key ways based on a [zizmor](https://docs.zizmor.sh/) scan:

- Consistently use `persist-credentials: false` per the [artipacked](https://docs.zizmor.sh/audits/#artipacked) rule. A hardening measure to avoid leaking credentials, already [in use once](https://github.com/sigstore/rekor-monitor/blob/672d3d16806a4b545e98d0b6535d0c2ea8a287ea/.github/workflows/release.yml#L45).
- Harden against [template injection](https://docs.zizmor.sh/audits/#template-injection). I opted to replace all uses of [GitHub Actions Expressions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions) (those `${{ }}` things) present in shell scripts by environment variables. This avoids any ambiguity about whether or not an attacker could control it and to what extend, just avoiding the issue altogether. This hardening is already in place for [one expression in a shell script](https://github.com/sigstore/rekor-monitor/blob/672d3d16806a4b545e98d0b6535d0c2ea8a287ea/.github/workflows/base_monitoring.yml#L68-L75).
  - In a few cases I went a bit beyond this mitigation and also wrapped the environment variable in double quotes to prevent [argument splitting](https://www.shellcheck.net/wiki/SC2086).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a